### PR TITLE
cleanup-client-struct

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -1,7 +1,10 @@
 defmodule AWS.Client do
+  @moduledoc """
+  Access and connections details needed when making requests to AWS services.
+  """
+
   defstruct access_key_id: nil,
             secret_access_key: nil,
-            session_token: nil,
             region: nil,
             endpoint: nil,
             service: nil

--- a/test/aws/request_test.exs
+++ b/test/aws/request_test.exs
@@ -6,7 +6,6 @@ defmodule AWS.RequestTest do
   test "sign_request/6 extracts credentials, service and region information from a Client map, generates an AWS signature version 4 for a request, and returns a new set of HTTP headers with Authorization and X-Aws-Date headers" do
     client = %Client{access_key_id: "access-key-id",
                      secret_access_key: "secret-access-key",
-                     session_token: nil,
                      region: "us-east-1",
                      service: "ec2"}
     now = Timex.Date.from({{2015, 5, 14}, {16, 50, 5}})


### PR DESCRIPTION
Remove unused `session_token` and add a simple module docstring to
`AWS.Client`.