### PR TITLE
better-variable-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased][unreleased]
+### Changed
+- All services return a `{:error, reason, response}` tuple when an
+  unsuccessful HTTP status code is returned (previously the `response` was not
+  included).
 
 ## [v0.0.4] - 2015-08-05
 ### Added

--- a/lib/aws/cloud_hsm.ex
+++ b/lib/aws/cloud_hsm.ex
@@ -10,8 +10,8 @@ defmodule AWS.CloudHSM do
   Creates a high-availability partition group. A high-availability partition
   group is a group of partitions that spans multiple physical HSMs.
   """
-  def create_hapg(client, input, options \\ []) do
-    request(client, "CreateHapg", input, options)
+  def create_hapg(client, input, http_options \\ []) do
+    request(client, "CreateHapg", input, http_options)
   end
 
   @doc """
@@ -29,74 +29,74 @@ defmodule AWS.CloudHSM do
 
   </important>
   """
-  def create_hsm(client, input, options \\ []) do
-    request(client, "CreateHsm", input, options)
+  def create_hsm(client, input, http_options \\ []) do
+    request(client, "CreateHsm", input, http_options)
   end
 
   @doc """
   Creates an HSM client.
   """
-  def create_luna_client(client, input, options \\ []) do
-    request(client, "CreateLunaClient", input, options)
+  def create_luna_client(client, input, http_options \\ []) do
+    request(client, "CreateLunaClient", input, http_options)
   end
 
   @doc """
   Deletes a high-availability partition group.
   """
-  def delete_hapg(client, input, options \\ []) do
-    request(client, "DeleteHapg", input, options)
+  def delete_hapg(client, input, http_options \\ []) do
+    request(client, "DeleteHapg", input, http_options)
   end
 
   @doc """
   Deletes an HSM. After completion, this operation cannot be undone and your
   key material cannot be recovered.
   """
-  def delete_hsm(client, input, options \\ []) do
-    request(client, "DeleteHsm", input, options)
+  def delete_hsm(client, input, http_options \\ []) do
+    request(client, "DeleteHsm", input, http_options)
   end
 
   @doc """
   Deletes a client.
   """
-  def delete_luna_client(client, input, options \\ []) do
-    request(client, "DeleteLunaClient", input, options)
+  def delete_luna_client(client, input, http_options \\ []) do
+    request(client, "DeleteLunaClient", input, http_options)
   end
 
   @doc """
   Retrieves information about a high-availability partition group.
   """
-  def describe_hapg(client, input, options \\ []) do
-    request(client, "DescribeHapg", input, options)
+  def describe_hapg(client, input, http_options \\ []) do
+    request(client, "DescribeHapg", input, http_options)
   end
 
   @doc """
   Retrieves information about an HSM. You can identify the HSM by its ARN or
   its serial number.
   """
-  def describe_hsm(client, input, options \\ []) do
-    request(client, "DescribeHsm", input, options)
+  def describe_hsm(client, input, http_options \\ []) do
+    request(client, "DescribeHsm", input, http_options)
   end
 
   @doc """
   Retrieves information about an HSM client.
   """
-  def describe_luna_client(client, input, options \\ []) do
-    request(client, "DescribeLunaClient", input, options)
+  def describe_luna_client(client, input, http_options \\ []) do
+    request(client, "DescribeLunaClient", input, http_options)
   end
 
   @doc """
   Gets the configuration files necessary to connect to all high availability
   partition groups the client is associated with.
   """
-  def get_config(client, input, options \\ []) do
-    request(client, "GetConfig", input, options)
+  def get_config(client, input, http_options \\ []) do
+    request(client, "GetConfig", input, http_options)
   end
 
   @doc """
   Lists the Availability Zones that have available AWS CloudHSM capacity.
   """
-  def list_available_zones(client, input, options \\ []) do
-    request(client, "ListAvailableZones", input, options)
+  def list_available_zones(client, input, http_options \\ []) do
+    request(client, "ListAvailableZones", input, http_options)
   end
 
   @doc """
@@ -107,8 +107,8 @@ defmodule AWS.CloudHSM do
   contains a token that you pass in the next call to `ListHapgs` to retrieve
   the next set of items.
   """
-  def list_hapgs(client, input, options \\ []) do
-    request(client, "ListHapgs", input, options)
+  def list_hapgs(client, input, http_options \\ []) do
+    request(client, "ListHapgs", input, http_options)
   end
 
   @doc """
@@ -120,8 +120,8 @@ defmodule AWS.CloudHSM do
   contains a token that you pass in the next call to `ListHsms` to retrieve
   the next set of items.
   """
-  def list_hsms(client, input, options \\ []) do
-    request(client, "ListHsms", input, options)
+  def list_hsms(client, input, http_options \\ []) do
+    request(client, "ListHsms", input, http_options)
   end
 
   @doc """
@@ -132,15 +132,15 @@ defmodule AWS.CloudHSM do
   contains a token that you pass in the next call to `ListLunaClients` to
   retrieve the next set of items.
   """
-  def list_luna_clients(client, input, options \\ []) do
-    request(client, "ListLunaClients", input, options)
+  def list_luna_clients(client, input, http_options \\ []) do
+    request(client, "ListLunaClients", input, http_options)
   end
 
   @doc """
   Modifies an existing high-availability partition group.
   """
-  def modify_hapg(client, input, options \\ []) do
-    request(client, "ModifyHapg", input, options)
+  def modify_hapg(client, input, http_options \\ []) do
+    request(client, "ModifyHapg", input, http_options)
   end
 
   @doc """
@@ -154,8 +154,8 @@ defmodule AWS.CloudHSM do
 
   </important>
   """
-  def modify_hsm(client, input, options \\ []) do
-    request(client, "ModifyHsm", input, options)
+  def modify_hsm(client, input, http_options \\ []) do
+    request(client, "ModifyHsm", input, http_options)
   end
 
   @doc """
@@ -164,11 +164,11 @@ defmodule AWS.CloudHSM do
   This action can potentially start a workflow to install the new certificate
   on the client's HSMs.
   """
-  def modify_luna_client(client, input, options \\ []) do
-    request(client, "ModifyLunaClient", input, options)
+  def modify_luna_client(client, input, http_options \\ []) do
+    request(client, "ModifyLunaClient", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "cloudhsm"}
     host = "cloudhsm.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -177,12 +177,12 @@ defmodule AWS.CloudHSM do
                {"X-Amz-Target", "CloudHsmFrontendService.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/cloud_trail.ex
+++ b/lib/aws/cloud_trail.ex
@@ -32,23 +32,23 @@ defmodule AWS.CloudTrail do
   Creates a trail that specifies the settings for delivery of log data to an
   Amazon S3 bucket.
   """
-  def create_trail(client, input, options \\ []) do
-    request(client, "CreateTrail", input, options)
+  def create_trail(client, input, http_options \\ []) do
+    request(client, "CreateTrail", input, http_options)
   end
 
   @doc """
   Deletes a trail.
   """
-  def delete_trail(client, input, options \\ []) do
-    request(client, "DeleteTrail", input, options)
+  def delete_trail(client, input, http_options \\ []) do
+    request(client, "DeleteTrail", input, http_options)
   end
 
   @doc """
   Retrieves settings for the trail associated with the current region for
   your account.
   """
-  def describe_trails(client, input, options \\ []) do
-    request(client, "DescribeTrails", input, options)
+  def describe_trails(client, input, http_options \\ []) do
+    request(client, "DescribeTrails", input, http_options)
   end
 
   @doc """
@@ -56,8 +56,8 @@ defmodule AWS.CloudTrail do
   Fields include information on delivery errors, Amazon SNS and Amazon S3
   errors, and start and stop logging times for each trail.
   """
-  def get_trail_status(client, input, options \\ []) do
-    request(client, "GetTrailStatus", input, options)
+  def get_trail_status(client, input, http_options \\ []) do
+    request(client, "GetTrailStatus", input, http_options)
   end
 
   @doc """
@@ -77,15 +77,15 @@ defmodule AWS.CloudTrail do
   available for lookup if CloudTrail logging was not enabled when the events
   occurred.</important>
   """
-  def lookup_events(client, input, options \\ []) do
-    request(client, "LookupEvents", input, options)
+  def lookup_events(client, input, http_options \\ []) do
+    request(client, "LookupEvents", input, http_options)
   end
 
   @doc """
   Starts the recording of AWS API calls and log file delivery for a trail.
   """
-  def start_logging(client, input, options \\ []) do
-    request(client, "StartLogging", input, options)
+  def start_logging(client, input, http_options \\ []) do
+    request(client, "StartLogging", input, http_options)
   end
 
   @doc """
@@ -94,8 +94,8 @@ defmodule AWS.CloudTrail do
   action. You can update a trail without stopping it first. This action is
   the only way to stop recording.
   """
-  def stop_logging(client, input, options \\ []) do
-    request(client, "StopLogging", input, options)
+  def stop_logging(client, input, http_options \\ []) do
+    request(client, "StopLogging", input, http_options)
   end
 
   @doc """
@@ -107,11 +107,11 @@ defmodule AWS.CloudTrail do
   previously been a target for CloudTrail log files, an IAM policy exists for
   the bucket.
   """
-  def update_trail(client, input, options \\ []) do
-    request(client, "UpdateTrail", input, options)
+  def update_trail(client, input, http_options \\ []) do
+    request(client, "UpdateTrail", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "cloudtrail"}
     host = "cloudtrail.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -120,12 +120,12 @@ defmodule AWS.CloudTrail do
                {"X-Amz-Target", "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/code_commit.ex
+++ b/lib/aws/code_commit.ex
@@ -27,8 +27,8 @@ defmodule AWS.CodeCommit do
 
   </note>
   """
-  def batch_get_repositories(client, input, options \\ []) do
-    request(client, "BatchGetRepositories", input, options)
+  def batch_get_repositories(client, input, http_options \\ []) do
+    request(client, "BatchGetRepositories", input, http_options)
   end
 
   @doc """
@@ -38,15 +38,15 @@ defmodule AWS.CodeCommit do
   default branch. To do this, call the update default branch
   operation.</note>
   """
-  def create_branch(client, input, options \\ []) do
-    request(client, "CreateBranch", input, options)
+  def create_branch(client, input, http_options \\ []) do
+    request(client, "CreateBranch", input, http_options)
   end
 
   @doc """
   Creates a new, empty repository.
   """
-  def create_repository(client, input, options \\ []) do
-    request(client, "CreateRepository", input, options)
+  def create_repository(client, input, http_options \\ []) do
+    request(client, "CreateRepository", input, http_options)
   end
 
   @doc """
@@ -57,16 +57,16 @@ defmodule AWS.CodeCommit do
   metadata. After a repository is deleted, all future push calls to the
   deleted repository will fail.</important>
   """
-  def delete_repository(client, input, options \\ []) do
-    request(client, "DeleteRepository", input, options)
+  def delete_repository(client, input, http_options \\ []) do
+    request(client, "DeleteRepository", input, http_options)
   end
 
   @doc """
   Retrieves information about a repository branch, including its name and the
   last commit ID.
   """
-  def get_branch(client, input, options \\ []) do
-    request(client, "GetBranch", input, options)
+  def get_branch(client, input, http_options \\ []) do
+    request(client, "GetBranch", input, http_options)
   end
 
   @doc """
@@ -81,22 +81,22 @@ defmodule AWS.CodeCommit do
 
   </note>
   """
-  def get_repository(client, input, options \\ []) do
-    request(client, "GetRepository", input, options)
+  def get_repository(client, input, http_options \\ []) do
+    request(client, "GetRepository", input, http_options)
   end
 
   @doc """
   Gets information about one or more branches in a repository.
   """
-  def list_branches(client, input, options \\ []) do
-    request(client, "ListBranches", input, options)
+  def list_branches(client, input, http_options \\ []) do
+    request(client, "ListBranches", input, http_options)
   end
 
   @doc """
   Gets information about one or more repositories.
   """
-  def list_repositories(client, input, options \\ []) do
-    request(client, "ListRepositories", input, options)
+  def list_repositories(client, input, http_options \\ []) do
+    request(client, "ListRepositories", input, http_options)
   end
 
   @doc """
@@ -106,8 +106,8 @@ defmodule AWS.CodeCommit do
   current default branch name, a success message is returned even though the
   default branch did not change.</note>
   """
-  def update_default_branch(client, input, options \\ []) do
-    request(client, "UpdateDefaultBranch", input, options)
+  def update_default_branch(client, input, http_options \\ []) do
+    request(client, "UpdateDefaultBranch", input, http_options)
   end
 
   @doc """
@@ -122,18 +122,18 @@ defmodule AWS.CodeCommit do
 
   </note>
   """
-  def update_repository_description(client, input, options \\ []) do
-    request(client, "UpdateRepositoryDescription", input, options)
+  def update_repository_description(client, input, http_options \\ []) do
+    request(client, "UpdateRepositoryDescription", input, http_options)
   end
 
   @doc """
   Renames a repository.
   """
-  def update_repository_name(client, input, options \\ []) do
-    request(client, "UpdateRepositoryName", input, options)
+  def update_repository_name(client, input, http_options \\ []) do
+    request(client, "UpdateRepositoryName", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "codecommit"}
     host = "codecommit.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -142,12 +142,12 @@ defmodule AWS.CodeCommit do
                {"X-Amz-Target", "CodeCommit_20150413.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/code_deploy.ex
+++ b/lib/aws/code_deploy.ex
@@ -67,64 +67,64 @@ defmodule AWS.CodeDeploy do
   @doc """
   Adds tags to on-premises instances.
   """
-  def add_tags_to_on_premises_instances(client, input, options \\ []) do
-    request(client, "AddTagsToOnPremisesInstances", input, options)
+  def add_tags_to_on_premises_instances(client, input, http_options \\ []) do
+    request(client, "AddTagsToOnPremisesInstances", input, http_options)
   end
 
   @doc """
   Gets information about one or more applications.
   """
-  def batch_get_applications(client, input, options \\ []) do
-    request(client, "BatchGetApplications", input, options)
+  def batch_get_applications(client, input, http_options \\ []) do
+    request(client, "BatchGetApplications", input, http_options)
   end
 
   @doc """
   Gets information about one or more deployments.
   """
-  def batch_get_deployments(client, input, options \\ []) do
-    request(client, "BatchGetDeployments", input, options)
+  def batch_get_deployments(client, input, http_options \\ []) do
+    request(client, "BatchGetDeployments", input, http_options)
   end
 
   @doc """
   Gets information about one or more on-premises instances.
   """
-  def batch_get_on_premises_instances(client, input, options \\ []) do
-    request(client, "BatchGetOnPremisesInstances", input, options)
+  def batch_get_on_premises_instances(client, input, http_options \\ []) do
+    request(client, "BatchGetOnPremisesInstances", input, http_options)
   end
 
   @doc """
   Creates a new application.
   """
-  def create_application(client, input, options \\ []) do
-    request(client, "CreateApplication", input, options)
+  def create_application(client, input, http_options \\ []) do
+    request(client, "CreateApplication", input, http_options)
   end
 
   @doc """
   Deploys an application revision through the specified deployment group.
   """
-  def create_deployment(client, input, options \\ []) do
-    request(client, "CreateDeployment", input, options)
+  def create_deployment(client, input, http_options \\ []) do
+    request(client, "CreateDeployment", input, http_options)
   end
 
   @doc """
   Creates a new deployment configuration.
   """
-  def create_deployment_config(client, input, options \\ []) do
-    request(client, "CreateDeploymentConfig", input, options)
+  def create_deployment_config(client, input, http_options \\ []) do
+    request(client, "CreateDeploymentConfig", input, http_options)
   end
 
   @doc """
   Creates a new deployment group for application revisions to be deployed to.
   """
-  def create_deployment_group(client, input, options \\ []) do
-    request(client, "CreateDeploymentGroup", input, options)
+  def create_deployment_group(client, input, http_options \\ []) do
+    request(client, "CreateDeploymentGroup", input, http_options)
   end
 
   @doc """
   Deletes an application.
   """
-  def delete_application(client, input, options \\ []) do
-    request(client, "DeleteApplication", input, options)
+  def delete_application(client, input, http_options \\ []) do
+    request(client, "DeleteApplication", input, http_options)
   end
 
   @doc """
@@ -133,118 +133,118 @@ defmodule AWS.CodeDeploy do
   <note>A deployment configuration cannot be deleted if it is currently in
   use. Also, predefined configurations cannot be deleted.</note>
   """
-  def delete_deployment_config(client, input, options \\ []) do
-    request(client, "DeleteDeploymentConfig", input, options)
+  def delete_deployment_config(client, input, http_options \\ []) do
+    request(client, "DeleteDeploymentConfig", input, http_options)
   end
 
   @doc """
   Deletes a deployment group.
   """
-  def delete_deployment_group(client, input, options \\ []) do
-    request(client, "DeleteDeploymentGroup", input, options)
+  def delete_deployment_group(client, input, http_options \\ []) do
+    request(client, "DeleteDeploymentGroup", input, http_options)
   end
 
   @doc """
   Deregisters an on-premises instance.
   """
-  def deregister_on_premises_instance(client, input, options \\ []) do
-    request(client, "DeregisterOnPremisesInstance", input, options)
+  def deregister_on_premises_instance(client, input, http_options \\ []) do
+    request(client, "DeregisterOnPremisesInstance", input, http_options)
   end
 
   @doc """
   Gets information about an application.
   """
-  def get_application(client, input, options \\ []) do
-    request(client, "GetApplication", input, options)
+  def get_application(client, input, http_options \\ []) do
+    request(client, "GetApplication", input, http_options)
   end
 
   @doc """
   Gets information about an application revision.
   """
-  def get_application_revision(client, input, options \\ []) do
-    request(client, "GetApplicationRevision", input, options)
+  def get_application_revision(client, input, http_options \\ []) do
+    request(client, "GetApplicationRevision", input, http_options)
   end
 
   @doc """
   Gets information about a deployment.
   """
-  def get_deployment(client, input, options \\ []) do
-    request(client, "GetDeployment", input, options)
+  def get_deployment(client, input, http_options \\ []) do
+    request(client, "GetDeployment", input, http_options)
   end
 
   @doc """
   Gets information about a deployment configuration.
   """
-  def get_deployment_config(client, input, options \\ []) do
-    request(client, "GetDeploymentConfig", input, options)
+  def get_deployment_config(client, input, http_options \\ []) do
+    request(client, "GetDeploymentConfig", input, http_options)
   end
 
   @doc """
   Gets information about a deployment group.
   """
-  def get_deployment_group(client, input, options \\ []) do
-    request(client, "GetDeploymentGroup", input, options)
+  def get_deployment_group(client, input, http_options \\ []) do
+    request(client, "GetDeploymentGroup", input, http_options)
   end
 
   @doc """
   Gets information about an instance as part of a deployment.
   """
-  def get_deployment_instance(client, input, options \\ []) do
-    request(client, "GetDeploymentInstance", input, options)
+  def get_deployment_instance(client, input, http_options \\ []) do
+    request(client, "GetDeploymentInstance", input, http_options)
   end
 
   @doc """
   Gets information about an on-premises instance.
   """
-  def get_on_premises_instance(client, input, options \\ []) do
-    request(client, "GetOnPremisesInstance", input, options)
+  def get_on_premises_instance(client, input, http_options \\ []) do
+    request(client, "GetOnPremisesInstance", input, http_options)
   end
 
   @doc """
   Lists information about revisions for an application.
   """
-  def list_application_revisions(client, input, options \\ []) do
-    request(client, "ListApplicationRevisions", input, options)
+  def list_application_revisions(client, input, http_options \\ []) do
+    request(client, "ListApplicationRevisions", input, http_options)
   end
 
   @doc """
   Lists the applications registered with the applicable IAM user or AWS
   account.
   """
-  def list_applications(client, input, options \\ []) do
-    request(client, "ListApplications", input, options)
+  def list_applications(client, input, http_options \\ []) do
+    request(client, "ListApplications", input, http_options)
   end
 
   @doc """
   Lists the deployment configurations with the applicable IAM user or AWS
   account.
   """
-  def list_deployment_configs(client, input, options \\ []) do
-    request(client, "ListDeploymentConfigs", input, options)
+  def list_deployment_configs(client, input, http_options \\ []) do
+    request(client, "ListDeploymentConfigs", input, http_options)
   end
 
   @doc """
   Lists the deployment groups for an application registered with the
   applicable IAM user or AWS account.
   """
-  def list_deployment_groups(client, input, options \\ []) do
-    request(client, "ListDeploymentGroups", input, options)
+  def list_deployment_groups(client, input, http_options \\ []) do
+    request(client, "ListDeploymentGroups", input, http_options)
   end
 
   @doc """
   Lists the instances for a deployment associated with the applicable IAM
   user or AWS account.
   """
-  def list_deployment_instances(client, input, options \\ []) do
-    request(client, "ListDeploymentInstances", input, options)
+  def list_deployment_instances(client, input, http_options \\ []) do
+    request(client, "ListDeploymentInstances", input, http_options)
   end
 
   @doc """
   Lists the deployments within a deployment group for an application
   registered with the applicable IAM user or AWS account.
   """
-  def list_deployments(client, input, options \\ []) do
-    request(client, "ListDeployments", input, options)
+  def list_deployments(client, input, http_options \\ []) do
+    request(client, "ListDeployments", input, http_options)
   end
 
   @doc """
@@ -254,53 +254,53 @@ defmodule AWS.CodeDeploy do
   instance names will be listed. To list only registered or deregistered
   on-premises instance names, use the registration status parameter.
   """
-  def list_on_premises_instances(client, input, options \\ []) do
-    request(client, "ListOnPremisesInstances", input, options)
+  def list_on_premises_instances(client, input, http_options \\ []) do
+    request(client, "ListOnPremisesInstances", input, http_options)
   end
 
   @doc """
   Registers with AWS CodeDeploy a revision for the specified application.
   """
-  def register_application_revision(client, input, options \\ []) do
-    request(client, "RegisterApplicationRevision", input, options)
+  def register_application_revision(client, input, http_options \\ []) do
+    request(client, "RegisterApplicationRevision", input, http_options)
   end
 
   @doc """
   Registers an on-premises instance.
   """
-  def register_on_premises_instance(client, input, options \\ []) do
-    request(client, "RegisterOnPremisesInstance", input, options)
+  def register_on_premises_instance(client, input, http_options \\ []) do
+    request(client, "RegisterOnPremisesInstance", input, http_options)
   end
 
   @doc """
   Removes one or more tags from one or more on-premises instances.
   """
-  def remove_tags_from_on_premises_instances(client, input, options \\ []) do
-    request(client, "RemoveTagsFromOnPremisesInstances", input, options)
+  def remove_tags_from_on_premises_instances(client, input, http_options \\ []) do
+    request(client, "RemoveTagsFromOnPremisesInstances", input, http_options)
   end
 
   @doc """
   Attempts to stop an ongoing deployment.
   """
-  def stop_deployment(client, input, options \\ []) do
-    request(client, "StopDeployment", input, options)
+  def stop_deployment(client, input, http_options \\ []) do
+    request(client, "StopDeployment", input, http_options)
   end
 
   @doc """
   Changes an existing application's name.
   """
-  def update_application(client, input, options \\ []) do
-    request(client, "UpdateApplication", input, options)
+  def update_application(client, input, http_options \\ []) do
+    request(client, "UpdateApplication", input, http_options)
   end
 
   @doc """
   Changes information about an existing deployment group.
   """
-  def update_deployment_group(client, input, options \\ []) do
-    request(client, "UpdateDeploymentGroup", input, options)
+  def update_deployment_group(client, input, http_options \\ []) do
+    request(client, "UpdateDeploymentGroup", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "codedeploy"}
     host = "codedeploy.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -309,12 +309,12 @@ defmodule AWS.CodeDeploy do
                {"X-Amz-Target", "CodeDeploy_20141006.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/code_pipeline.ex
+++ b/lib/aws/code_pipeline.ex
@@ -93,31 +93,31 @@ defmodule AWS.CodePipeline do
   Returns information about a specified job and whether that job has been
   received by the job worker. Only used for custom actions.
   """
-  def acknowledge_job(client, input, options \\ []) do
-    request(client, "AcknowledgeJob", input, options)
+  def acknowledge_job(client, input, http_options \\ []) do
+    request(client, "AcknowledgeJob", input, http_options)
   end
 
   @doc """
   Confirms a job worker has received the specified job. Only used for partner
   actions.
   """
-  def acknowledge_third_party_job(client, input, options \\ []) do
-    request(client, "AcknowledgeThirdPartyJob", input, options)
+  def acknowledge_third_party_job(client, input, http_options \\ []) do
+    request(client, "AcknowledgeThirdPartyJob", input, http_options)
   end
 
   @doc """
   Creates a new custom action that can be used in all pipelines associated
   with the AWS account. Only used for custom actions.
   """
-  def create_custom_action_type(client, input, options \\ []) do
-    request(client, "CreateCustomActionType", input, options)
+  def create_custom_action_type(client, input, http_options \\ []) do
+    request(client, "CreateCustomActionType", input, http_options)
   end
 
   @doc """
   Creates a pipeline.
   """
-  def create_pipeline(client, input, options \\ []) do
-    request(client, "CreatePipeline", input, options)
+  def create_pipeline(client, input, http_options \\ []) do
+    request(client, "CreatePipeline", input, http_options)
   end
 
   @doc """
@@ -129,30 +129,30 @@ defmodule AWS.CodePipeline do
 
   </important>
   """
-  def delete_custom_action_type(client, input, options \\ []) do
-    request(client, "DeleteCustomActionType", input, options)
+  def delete_custom_action_type(client, input, http_options \\ []) do
+    request(client, "DeleteCustomActionType", input, http_options)
   end
 
   @doc """
   Deletes the specified pipeline.
   """
-  def delete_pipeline(client, input, options \\ []) do
-    request(client, "DeletePipeline", input, options)
+  def delete_pipeline(client, input, http_options \\ []) do
+    request(client, "DeletePipeline", input, http_options)
   end
 
   @doc """
   Prevents artifacts in a pipeline from transitioning to the next stage in
   the pipeline.
   """
-  def disable_stage_transition(client, input, options \\ []) do
-    request(client, "DisableStageTransition", input, options)
+  def disable_stage_transition(client, input, http_options \\ []) do
+    request(client, "DisableStageTransition", input, http_options)
   end
 
   @doc """
   Enables artifacts in a pipeline to transition to a stage in a pipeline.
   """
-  def enable_stage_transition(client, input, options \\ []) do
-    request(client, "EnableStageTransition", input, options)
+  def enable_stage_transition(client, input, http_options \\ []) do
+    request(client, "EnableStageTransition", input, http_options)
   end
 
   @doc """
@@ -166,8 +166,8 @@ defmodule AWS.CodePipeline do
 
   </important>
   """
-  def get_job_details(client, input, options \\ []) do
-    request(client, "GetJobDetails", input, options)
+  def get_job_details(client, input, http_options \\ []) do
+    request(client, "GetJobDetails", input, http_options)
   end
 
   @doc """
@@ -176,16 +176,16 @@ defmodule AWS.CodePipeline do
   then be modified and used to update the pipeline structure with
   `UpdatePipeline`.
   """
-  def get_pipeline(client, input, options \\ []) do
-    request(client, "GetPipeline", input, options)
+  def get_pipeline(client, input, http_options \\ []) do
+    request(client, "GetPipeline", input, http_options)
   end
 
   @doc """
   Returns information about the state of a pipeline, including the stages,
   actions, and details about the last run of the pipeline.
   """
-  def get_pipeline_state(client, input, options \\ []) do
-    request(client, "GetPipelineState", input, options)
+  def get_pipeline_state(client, input, http_options \\ []) do
+    request(client, "GetPipelineState", input, http_options)
   end
 
   @doc """
@@ -200,23 +200,23 @@ defmodule AWS.CodePipeline do
 
   </important>
   """
-  def get_third_party_job_details(client, input, options \\ []) do
-    request(client, "GetThirdPartyJobDetails", input, options)
+  def get_third_party_job_details(client, input, http_options \\ []) do
+    request(client, "GetThirdPartyJobDetails", input, http_options)
   end
 
   @doc """
   Gets a summary of all AWS CodePipeline action types associated with your
   account.
   """
-  def list_action_types(client, input, options \\ []) do
-    request(client, "ListActionTypes", input, options)
+  def list_action_types(client, input, http_options \\ []) do
+    request(client, "ListActionTypes", input, http_options)
   end
 
   @doc """
   Gets a summary of all of the pipelines associated with your account.
   """
-  def list_pipelines(client, input, options \\ []) do
-    request(client, "ListPipelines", input, options)
+  def list_pipelines(client, input, http_options \\ []) do
+    request(client, "ListPipelines", input, http_options)
   end
 
   @doc """
@@ -230,8 +230,8 @@ defmodule AWS.CodePipeline do
 
   </important>
   """
-  def poll_for_jobs(client, input, options \\ []) do
-    request(client, "PollForJobs", input, options)
+  def poll_for_jobs(client, input, http_options \\ []) do
+    request(client, "PollForJobs", input, http_options)
   end
 
   @doc """
@@ -245,55 +245,55 @@ defmodule AWS.CodePipeline do
 
   </important>
   """
-  def poll_for_third_party_jobs(client, input, options \\ []) do
-    request(client, "PollForThirdPartyJobs", input, options)
+  def poll_for_third_party_jobs(client, input, http_options \\ []) do
+    request(client, "PollForThirdPartyJobs", input, http_options)
   end
 
   @doc """
   Provides information to AWS CodePipeline about new revisions to a source.
   """
-  def put_action_revision(client, input, options \\ []) do
-    request(client, "PutActionRevision", input, options)
+  def put_action_revision(client, input, http_options \\ []) do
+    request(client, "PutActionRevision", input, http_options)
   end
 
   @doc """
   Represents the failure of a job as returned to the pipeline by a job
   worker. Only used for custom actions.
   """
-  def put_job_failure_result(client, input, options \\ []) do
-    request(client, "PutJobFailureResult", input, options)
+  def put_job_failure_result(client, input, http_options \\ []) do
+    request(client, "PutJobFailureResult", input, http_options)
   end
 
   @doc """
   Represents the success of a job as returned to the pipeline by a job
   worker. Only used for custom actions.
   """
-  def put_job_success_result(client, input, options \\ []) do
-    request(client, "PutJobSuccessResult", input, options)
+  def put_job_success_result(client, input, http_options \\ []) do
+    request(client, "PutJobSuccessResult", input, http_options)
   end
 
   @doc """
   Represents the failure of a third party job as returned to the pipeline by
   a job worker. Only used for partner actions.
   """
-  def put_third_party_job_failure_result(client, input, options \\ []) do
-    request(client, "PutThirdPartyJobFailureResult", input, options)
+  def put_third_party_job_failure_result(client, input, http_options \\ []) do
+    request(client, "PutThirdPartyJobFailureResult", input, http_options)
   end
 
   @doc """
   Represents the success of a third party job as returned to the pipeline by
   a job worker. Only used for partner actions.
   """
-  def put_third_party_job_success_result(client, input, options \\ []) do
-    request(client, "PutThirdPartyJobSuccessResult", input, options)
+  def put_third_party_job_success_result(client, input, http_options \\ []) do
+    request(client, "PutThirdPartyJobSuccessResult", input, http_options)
   end
 
   @doc """
   Starts the specified pipeline. Specifically, it begins processing the
   latest commit to the source location specified as part of the pipeline.
   """
-  def start_pipeline_execution(client, input, options \\ []) do
-    request(client, "StartPipelineExecution", input, options)
+  def start_pipeline_execution(client, input, http_options \\ []) do
+    request(client, "StartPipelineExecution", input, http_options)
   end
 
   @doc """
@@ -302,11 +302,11 @@ defmodule AWS.CodePipeline do
   provide the full structure of the pipeline. Updating the pipeline increases
   the version number of the pipeline by 1.
   """
-  def update_pipeline(client, input, options \\ []) do
-    request(client, "UpdatePipeline", input, options)
+  def update_pipeline(client, input, http_options \\ []) do
+    request(client, "UpdatePipeline", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "codepipeline"}
     host = "codepipeline.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -315,12 +315,12 @@ defmodule AWS.CodePipeline do
                {"X-Amz-Target", "CodePipeline_20150709.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/cognito.ex
+++ b/lib/aws/cognito.ex
@@ -48,8 +48,8 @@ defmodule AWS.Cognito do
   pools is 60 per account. You must use AWS Developer credentials to call
   this API.
   """
-  def create_identity_pool(client, input, options \\ []) do
-    request(client, "CreateIdentityPool", input, options)
+  def create_identity_pool(client, input, http_options \\ []) do
+    request(client, "CreateIdentityPool", input, http_options)
   end
 
   @doc """
@@ -58,8 +58,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def delete_identities(client, input, options \\ []) do
-    request(client, "DeleteIdentities", input, options)
+  def delete_identities(client, input, http_options \\ []) do
+    request(client, "DeleteIdentities", input, http_options)
   end
 
   @doc """
@@ -68,8 +68,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def delete_identity_pool(client, input, options \\ []) do
-    request(client, "DeleteIdentityPool", input, options)
+  def delete_identity_pool(client, input, http_options \\ []) do
+    request(client, "DeleteIdentityPool", input, http_options)
   end
 
   @doc """
@@ -78,8 +78,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def describe_identity(client, input, options \\ []) do
-    request(client, "DescribeIdentity", input, options)
+  def describe_identity(client, input, http_options \\ []) do
+    request(client, "DescribeIdentity", input, http_options)
   end
 
   @doc """
@@ -88,8 +88,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def describe_identity_pool(client, input, options \\ []) do
-    request(client, "DescribeIdentityPool", input, options)
+  def describe_identity_pool(client, input, http_options \\ []) do
+    request(client, "DescribeIdentityPool", input, http_options)
   end
 
   @doc """
@@ -100,8 +100,8 @@ defmodule AWS.Cognito do
 
   This is a public API. You do not need any credentials to call this API.
   """
-  def get_credentials_for_identity(client, input, options \\ []) do
-    request(client, "GetCredentialsForIdentity", input, options)
+  def get_credentials_for_identity(client, input, http_options \\ []) do
+    request(client, "GetCredentialsForIdentity", input, http_options)
   end
 
   @doc """
@@ -112,8 +112,8 @@ defmodule AWS.Cognito do
 
   This is a public API. You do not need any credentials to call this API.
   """
-  def get_id(client, input, options \\ []) do
-    request(client, "GetId", input, options)
+  def get_id(client, input, http_options \\ []) do
+    request(client, "GetId", input, http_options)
   end
 
   @doc """
@@ -121,8 +121,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def get_identity_pool_roles(client, input, options \\ []) do
-    request(client, "GetIdentityPoolRoles", input, options)
+  def get_identity_pool_roles(client, input, http_options \\ []) do
+    request(client, "GetIdentityPoolRoles", input, http_options)
   end
 
   @doc """
@@ -134,8 +134,8 @@ defmodule AWS.Cognito do
 
   This is a public API. You do not need any credentials to call this API.
   """
-  def get_open_id_token(client, input, options \\ []) do
-    request(client, "GetOpenIdToken", input, options)
+  def get_open_id_token(client, input, http_options \\ []) do
+    request(client, "GetOpenIdToken", input, http_options)
   end
 
   @doc """
@@ -156,8 +156,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def get_open_id_token_for_developer_identity(client, input, options \\ []) do
-    request(client, "GetOpenIdTokenForDeveloperIdentity", input, options)
+  def get_open_id_token_for_developer_identity(client, input, http_options \\ []) do
+    request(client, "GetOpenIdTokenForDeveloperIdentity", input, http_options)
   end
 
   @doc """
@@ -165,8 +165,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def list_identities(client, input, options \\ []) do
-    request(client, "ListIdentities", input, options)
+  def list_identities(client, input, http_options \\ []) do
+    request(client, "ListIdentities", input, http_options)
   end
 
   @doc """
@@ -174,8 +174,8 @@ defmodule AWS.Cognito do
 
   This is a public API. You do not need any credentials to call this API.
   """
-  def list_identity_pools(client, input, options \\ []) do
-    request(client, "ListIdentityPools", input, options)
+  def list_identity_pools(client, input, http_options \\ []) do
+    request(client, "ListIdentityPools", input, http_options)
   end
 
   @doc """
@@ -191,8 +191,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def lookup_developer_identity(client, input, options \\ []) do
-    request(client, "LookupDeveloperIdentity", input, options)
+  def lookup_developer_identity(client, input, http_options \\ []) do
+    request(client, "LookupDeveloperIdentity", input, http_options)
   end
 
   @doc """
@@ -207,8 +207,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def merge_developer_identities(client, input, options \\ []) do
-    request(client, "MergeDeveloperIdentities", input, options)
+  def merge_developer_identities(client, input, http_options \\ []) do
+    request(client, "MergeDeveloperIdentities", input, http_options)
   end
 
   @doc """
@@ -217,8 +217,8 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def set_identity_pool_roles(client, input, options \\ []) do
-    request(client, "SetIdentityPoolRoles", input, options)
+  def set_identity_pool_roles(client, input, http_options \\ []) do
+    request(client, "SetIdentityPoolRoles", input, http_options)
   end
 
   @doc """
@@ -230,8 +230,8 @@ defmodule AWS.Cognito do
 
   This is a public API. You do not need any credentials to call this API.
   """
-  def unlink_developer_identity(client, input, options \\ []) do
-    request(client, "UnlinkDeveloperIdentity", input, options)
+  def unlink_developer_identity(client, input, http_options \\ []) do
+    request(client, "UnlinkDeveloperIdentity", input, http_options)
   end
 
   @doc """
@@ -241,8 +241,8 @@ defmodule AWS.Cognito do
 
   This is a public API. You do not need any credentials to call this API.
   """
-  def unlink_identity(client, input, options \\ []) do
-    request(client, "UnlinkIdentity", input, options)
+  def unlink_identity(client, input, http_options \\ []) do
+    request(client, "UnlinkIdentity", input, http_options)
   end
 
   @doc """
@@ -250,11 +250,11 @@ defmodule AWS.Cognito do
 
   You must use AWS Developer credentials to call this API.
   """
-  def update_identity_pool(client, input, options \\ []) do
-    request(client, "UpdateIdentityPool", input, options)
+  def update_identity_pool(client, input, http_options \\ []) do
+    request(client, "UpdateIdentityPool", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "cognito-identity"}
     host = "cognito-identity.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -263,12 +263,12 @@ defmodule AWS.Cognito do
                {"X-Amz-Target", "AWSCognitoIdentityService.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/cognito_sync.ex
+++ b/lib/aws/cognito_sync.ex
@@ -38,10 +38,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with developer credentials. You cannot call
   this API with the temporary user credentials provided by Cognito Identity.
   """
-  def bulk_publish(client, identity_pool_id, input, options \\ []) do
+  def bulk_publish(client, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/bulkpublish"
     headers = []
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -53,10 +53,10 @@ defmodule AWS.Cognito.Sync do
   This API can be called with temporary user credentials provided by Cognito
   Identity or with developer credentials.
   """
-  def delete_dataset(client, dataset_name, identity_id, identity_pool_id, input, options \\ []) do
+  def delete_dataset(client, dataset_name, identity_id, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identities/#{URI.encode(identity_id)}/datasets/#{URI.encode(dataset_name)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 200)
+    request(client, :delete, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -69,10 +69,10 @@ defmodule AWS.Cognito.Sync do
   Identity or with developer credentials. You should use Cognito Identity
   credentials to make this API call.
   """
-  def describe_dataset(client, dataset_name, identity_id, identity_pool_id, options \\ []) do
+  def describe_dataset(client, dataset_name, identity_id, identity_pool_id, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identities/#{URI.encode(identity_id)}/datasets/#{URI.encode(dataset_name)}"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -82,10 +82,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with developer credentials. You cannot call
   this API with the temporary user credentials provided by Cognito Identity.
   """
-  def describe_identity_pool_usage(client, identity_pool_id, options \\ []) do
+  def describe_identity_pool_usage(client, identity_pool_id, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -95,10 +95,10 @@ defmodule AWS.Cognito.Sync do
   This API can be called with temporary user credentials provided by Cognito
   Identity or with developer credentials.
   """
-  def describe_identity_usage(client, identity_id, identity_pool_id, options \\ []) do
+  def describe_identity_usage(client, identity_id, identity_pool_id, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identities/#{URI.encode(identity_id)}"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -107,10 +107,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with developer credentials. You cannot call
   this API with the temporary user credentials provided by Cognito Identity.
   """
-  def get_bulk_publish_details(client, identity_pool_id, input, options \\ []) do
+  def get_bulk_publish_details(client, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/getBulkPublishDetails"
     headers = []
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -120,10 +120,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with developer credentials. You cannot call
   this API with the temporary user credentials provided by Cognito Identity.
   """
-  def get_cognito_events(client, identity_pool_id, options \\ []) do
+  def get_cognito_events(client, identity_pool_id, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/events"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -132,10 +132,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with developer credentials. You cannot call
   this API with the temporary user credentials provided by Cognito Identity.
   """
-  def get_identity_pool_configuration(client, identity_pool_id, options \\ []) do
+  def get_identity_pool_configuration(client, identity_pool_id, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/configuration"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -147,10 +147,10 @@ defmodule AWS.Cognito.Sync do
   Cognito Identity or with developer credentials. You should use the Cognito
   Identity credentials to make this API call.
   """
-  def list_datasets(client, identity_id, identity_pool_id, options \\ []) do
+  def list_datasets(client, identity_id, identity_pool_id, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identities/#{URI.encode(identity_id)}/datasets"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -160,10 +160,10 @@ defmodule AWS.Cognito.Sync do
   cannot make this API call with the temporary user credentials provided by
   Cognito Identity.
   """
-  def list_identity_pool_usage(client, options \\ []) do
+  def list_identity_pool_usage(client, http_options \\ []) do
     url = "/identitypools"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -176,10 +176,10 @@ defmodule AWS.Cognito.Sync do
   Cognito Identity or with developer credentials. You should use Cognito
   Identity credentials to make this API call.
   """
-  def list_records(client, dataset_name, identity_id, identity_pool_id, options \\ []) do
+  def list_records(client, dataset_name, identity_id, identity_pool_id, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identities/#{URI.encode(identity_id)}/datasets/#{URI.encode(dataset_name)}/records"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -188,10 +188,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with temporary credentials provided by Cognito
   Identity. You cannot call this API with developer credentials.
   """
-  def register_device(client, identity_id, identity_pool_id, input, options \\ []) do
+  def register_device(client, identity_id, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identity/#{URI.encode(identity_id)}/device"
     headers = []
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -203,10 +203,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with developer credentials. You cannot call
   this API with the temporary user credentials provided by Cognito Identity.
   """
-  def set_cognito_events(client, identity_pool_id, input, options \\ []) do
+  def set_cognito_events(client, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/events"
     headers = []
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -215,10 +215,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with developer credentials. You cannot call
   this API with the temporary user credentials provided by Cognito Identity.
   """
-  def set_identity_pool_configuration(client, identity_pool_id, input, options \\ []) do
+  def set_identity_pool_configuration(client, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/configuration"
     headers = []
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -228,10 +228,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with temporary credentials provided by Cognito
   Identity. You cannot call this API with developer credentials.
   """
-  def subscribe_to_dataset(client, dataset_name, device_id, identity_id, identity_pool_id, input, options \\ []) do
+  def subscribe_to_dataset(client, dataset_name, device_id, identity_id, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identities/#{URI.encode(identity_id)}/datasets/#{URI.encode(dataset_name)}/subscriptions/#{URI.encode(device_id)}"
     headers = []
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -241,10 +241,10 @@ defmodule AWS.Cognito.Sync do
   This API can only be called with temporary credentials provided by Cognito
   Identity. You cannot call this API with developer credentials.
   """
-  def unsubscribe_from_dataset(client, dataset_name, device_id, identity_id, identity_pool_id, input, options \\ []) do
+  def unsubscribe_from_dataset(client, dataset_name, device_id, identity_id, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identities/#{URI.encode(identity_id)}/datasets/#{URI.encode(dataset_name)}/subscriptions/#{URI.encode(device_id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 200)
+    request(client, :delete, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -267,17 +267,17 @@ defmodule AWS.Cognito.Sync do
   This API can be called with temporary user credentials provided by Cognito
   Identity or with developer credentials.
   """
-  def update_records(client, dataset_name, identity_id, identity_pool_id, input, options \\ []) do
+  def update_records(client, dataset_name, identity_id, identity_pool_id, input, http_options \\ []) do
     url = "/identitypools/#{URI.encode(identity_pool_id)}/identities/#{URI.encode(identity_id)}/datasets/#{URI.encode(dataset_name)}"
     headers = []
     if Dict.has_key?(input, "ClientContext") do
       headers = [{"ClientContext", input["ClientContext"]}|headers]
       input = Dict.delete(input, "ClientContext")
     end
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
-  defp request(client, method, url, headers, input, options, success_status_code) do
+  defp request(client, method, url, headers, input, http_options, success_status_code) do
     client = %{client | service: "cognito-sync"}
     host = "cognito-sync.#{client.region}.#{client.endpoint}"
     url = "https://#{host}#{url}"
@@ -286,32 +286,32 @@ defmodule AWS.Cognito.Sync do
                           headers)
     payload = encode_payload(input)
     headers = AWS.Request.sign_v4(client, method, url, headers, payload)
-    perform_request(method, url, payload, headers, options, success_status_code)
+    perform_request(method, url, payload, headers, http_options, success_status_code)
   end
 
-  defp perform_request(method, url, payload, headers, options, nil) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, nil) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 202, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 204, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end
   end
 
-  defp perform_request(method, url, payload, headers, options, success_status_code) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, success_status_code) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/config.ex
+++ b/lib/aws/config.ex
@@ -42,8 +42,8 @@ defmodule AWS.Config do
   channel, stop the running configuration recorder using the
   `StopConfigurationRecorder` action.
   """
-  def delete_delivery_channel(client, input, options \\ []) do
-    request(client, "DeleteDeliveryChannel", input, options)
+  def delete_delivery_channel(client, input, http_options \\ []) do
+    request(client, "DeleteDeliveryChannel", input, http_options)
   end
 
   @doc """
@@ -57,8 +57,8 @@ defmodule AWS.Config do
   <li>Notification of delivery failure, if the delivery failed to
   complete.</li> </ul>
   """
-  def deliver_config_snapshot(client, input, options \\ []) do
-    request(client, "DeliverConfigSnapshot", input, options)
+  def deliver_config_snapshot(client, input, http_options \\ []) do
+    request(client, "DeliverConfigSnapshot", input, http_options)
   end
 
   @doc """
@@ -69,8 +69,8 @@ defmodule AWS.Config do
   <note>Currently, you can specify only one configuration recorder per
   account.</note>
   """
-  def describe_configuration_recorder_status(client, input, options \\ []) do
-    request(client, "DescribeConfigurationRecorderStatus", input, options)
+  def describe_configuration_recorder_status(client, input, http_options \\ []) do
+    request(client, "DescribeConfigurationRecorderStatus", input, http_options)
   end
 
   @doc """
@@ -83,8 +83,8 @@ defmodule AWS.Config do
 
   </note>
   """
-  def describe_configuration_recorders(client, input, options \\ []) do
-    request(client, "DescribeConfigurationRecorders", input, options)
+  def describe_configuration_recorders(client, input, http_options \\ []) do
+    request(client, "DescribeConfigurationRecorders", input, http_options)
   end
 
   @doc """
@@ -95,8 +95,8 @@ defmodule AWS.Config do
   <note>Currently, you can specify only one delivery channel per
   account.</note>
   """
-  def describe_delivery_channel_status(client, input, options \\ []) do
-    request(client, "DescribeDeliveryChannelStatus", input, options)
+  def describe_delivery_channel_status(client, input, http_options \\ []) do
+    request(client, "DescribeDeliveryChannelStatus", input, http_options)
   end
 
   @doc """
@@ -108,8 +108,8 @@ defmodule AWS.Config do
 
   </note>
   """
-  def describe_delivery_channels(client, input, options \\ []) do
-    request(client, "DescribeDeliveryChannels", input, options)
+  def describe_delivery_channels(client, input, http_options \\ []) do
+    request(client, "DescribeDeliveryChannels", input, http_options)
   end
 
   @doc """
@@ -125,8 +125,8 @@ defmodule AWS.Config do
 
   </note>
   """
-  def get_resource_config_history(client, input, options \\ []) do
-    request(client, "GetResourceConfigHistory", input, options)
+  def get_resource_config_history(client, input, http_options \\ []) do
+    request(client, "GetResourceConfigHistory", input, http_options)
   end
 
   @doc """
@@ -145,8 +145,8 @@ defmodule AWS.Config do
 
   </note>
   """
-  def put_configuration_recorder(client, input, options \\ []) do
-    request(client, "PutConfigurationRecorder", input, options)
+  def put_configuration_recorder(client, input, http_options \\ []) do
+    request(client, "PutConfigurationRecorder", input, http_options)
   end
 
   @doc """
@@ -164,8 +164,8 @@ defmodule AWS.Config do
 
   </note>
   """
-  def put_delivery_channel(client, input, options \\ []) do
-    request(client, "PutDeliveryChannel", input, options)
+  def put_delivery_channel(client, input, http_options \\ []) do
+    request(client, "PutDeliveryChannel", input, http_options)
   end
 
   @doc """
@@ -175,19 +175,19 @@ defmodule AWS.Config do
   You must have created at least one delivery channel to successfully start
   the configuration recorder.
   """
-  def start_configuration_recorder(client, input, options \\ []) do
-    request(client, "StartConfigurationRecorder", input, options)
+  def start_configuration_recorder(client, input, http_options \\ []) do
+    request(client, "StartConfigurationRecorder", input, http_options)
   end
 
   @doc """
   Stops recording configurations of the AWS resources you have selected to
   record in your AWS account.
   """
-  def stop_configuration_recorder(client, input, options \\ []) do
-    request(client, "StopConfigurationRecorder", input, options)
+  def stop_configuration_recorder(client, input, http_options \\ []) do
+    request(client, "StopConfigurationRecorder", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "config"}
     host = "config.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -196,12 +196,12 @@ defmodule AWS.Config do
                {"X-Amz-Target", "StarlingDoveService.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/data_pipeline.ex
+++ b/lib/aws/data_pipeline.ex
@@ -37,23 +37,23 @@ defmodule AWS.DataPipeline do
   To activate a finished pipeline, modify the end date for the pipeline and
   then activate it.
   """
-  def activate_pipeline(client, input, options \\ []) do
-    request(client, "ActivatePipeline", input, options)
+  def activate_pipeline(client, input, http_options \\ []) do
+    request(client, "ActivatePipeline", input, http_options)
   end
 
   @doc """
   Adds or modifies tags for the specified pipeline.
   """
-  def add_tags(client, input, options \\ []) do
-    request(client, "AddTags", input, options)
+  def add_tags(client, input, http_options \\ []) do
+    request(client, "AddTags", input, http_options)
   end
 
   @doc """
   Creates a new, empty pipeline. Use `PutPipelineDefinition` to populate the
   pipeline.
   """
-  def create_pipeline(client, input, options \\ []) do
-    request(client, "CreatePipeline", input, options)
+  def create_pipeline(client, input, http_options \\ []) do
+    request(client, "CreatePipeline", input, http_options)
   end
 
   @doc """
@@ -64,8 +64,8 @@ defmodule AWS.DataPipeline do
   pipeline resumes from the last completed execution. Optionally, you can
   specify the date and time to resume the pipeline.
   """
-  def deactivate_pipeline(client, input, options \\ []) do
-    request(client, "DeactivatePipeline", input, options)
+  def deactivate_pipeline(client, input, http_options \\ []) do
+    request(client, "DeactivatePipeline", input, http_options)
   end
 
   @doc """
@@ -78,8 +78,8 @@ defmodule AWS.DataPipeline do
   `SetStatus` with the status set to `PAUSE` on individual components.
   Components that are paused by `SetStatus` can be resumed.
   """
-  def delete_pipeline(client, input, options \\ []) do
-    request(client, "DeletePipeline", input, options)
+  def delete_pipeline(client, input, http_options \\ []) do
+    request(client, "DeletePipeline", input, http_options)
   end
 
   @doc """
@@ -87,8 +87,8 @@ defmodule AWS.DataPipeline do
   pipeline. Object definitions are composed of a set of fields that define
   the properties of the object.
   """
-  def describe_objects(client, input, options \\ []) do
-    request(client, "DescribeObjects", input, options)
+  def describe_objects(client, input, http_options \\ []) do
+    request(client, "DescribeObjects", input, http_options)
   end
 
   @doc """
@@ -102,8 +102,8 @@ defmodule AWS.DataPipeline do
   To retrieve the full pipeline definition instead of metadata about the
   pipeline, call `GetPipelineDefinition`.
   """
-  def describe_pipelines(client, input, options \\ []) do
-    request(client, "DescribePipelines", input, options)
+  def describe_pipelines(client, input, http_options \\ []) do
+    request(client, "DescribePipelines", input, http_options)
   end
 
   @doc """
@@ -111,8 +111,8 @@ defmodule AWS.DataPipeline do
   of the specified object. For example, a task runner can evaluate SQL
   queries stored in Amazon S3.
   """
-  def evaluate_expression(client, input, options \\ []) do
-    request(client, "EvaluateExpression", input, options)
+  def evaluate_expression(client, input, http_options \\ []) do
+    request(client, "EvaluateExpression", input, http_options)
   end
 
   @doc """
@@ -120,16 +120,16 @@ defmodule AWS.DataPipeline do
   `GetPipelineDefinition` to retrieve the pipeline definition that you
   provided using `PutPipelineDefinition`.
   """
-  def get_pipeline_definition(client, input, options \\ []) do
-    request(client, "GetPipelineDefinition", input, options)
+  def get_pipeline_definition(client, input, http_options \\ []) do
+    request(client, "GetPipelineDefinition", input, http_options)
   end
 
   @doc """
   Lists the pipeline identifiers for all active pipelines that you have
   permission to access.
   """
-  def list_pipelines(client, input, options \\ []) do
-    request(client, "ListPipelines", input, options)
+  def list_pipelines(client, input, http_options \\ []) do
+    request(client, "ListPipelines", input, http_options)
   end
 
   @doc """
@@ -149,8 +149,8 @@ defmodule AWS.DataPipeline do
   `workerGroup` until it receives a response, and this can take up to 90
   seconds.
   """
-  def poll_for_task(client, input, options \\ []) do
-    request(client, "PollForTask", input, options)
+  def poll_for_task(client, input, http_options \\ []) do
+    request(client, "PollForTask", input, http_options)
   end
 
   @doc """
@@ -168,23 +168,23 @@ defmodule AWS.DataPipeline do
   `PutPipelineDefinition` action and returned by the `GetPipelineDefinition`
   action.
   """
-  def put_pipeline_definition(client, input, options \\ []) do
-    request(client, "PutPipelineDefinition", input, options)
+  def put_pipeline_definition(client, input, http_options \\ []) do
+    request(client, "PutPipelineDefinition", input, http_options)
   end
 
   @doc """
   Queries the specified pipeline for the names of objects that match the
   specified set of conditions.
   """
-  def query_objects(client, input, options \\ []) do
-    request(client, "QueryObjects", input, options)
+  def query_objects(client, input, http_options \\ []) do
+    request(client, "QueryObjects", input, http_options)
   end
 
   @doc """
   Removes existing tags from the specified pipeline.
   """
-  def remove_tags(client, input, options \\ []) do
-    request(client, "RemoveTags", input, options)
+  def remove_tags(client, input, http_options \\ []) do
+    request(client, "RemoveTags", input, http_options)
   end
 
   @doc """
@@ -201,8 +201,8 @@ defmodule AWS.DataPipeline do
   reassigns the task in a subsequent response to `PollForTask`. Task runners
   should call `ReportTaskProgress` every 60 seconds.
   """
-  def report_task_progress(client, input, options \\ []) do
-    request(client, "ReportTaskProgress", input, options)
+  def report_task_progress(client, input, http_options \\ []) do
+    request(client, "ReportTaskProgress", input, http_options)
   end
 
   @doc """
@@ -212,8 +212,8 @@ defmodule AWS.DataPipeline do
   call to detect when the task runner application has failed and restart a
   new instance.
   """
-  def report_task_runner_heartbeat(client, input, options \\ []) do
-    request(client, "ReportTaskRunnerHeartbeat", input, options)
+  def report_task_runner_heartbeat(client, input, http_options \\ []) do
+    request(client, "ReportTaskRunnerHeartbeat", input, http_options)
   end
 
   @doc """
@@ -224,8 +224,8 @@ defmodule AWS.DataPipeline do
   cannot perform this operation on `FINISHED` pipelines and attempting to do
   so returns `InvalidRequestException`.
   """
-  def set_status(client, input, options \\ []) do
-    request(client, "SetStatus", input, options)
+  def set_status(client, input, http_options \\ []) do
+    request(client, "SetStatus", input, http_options)
   end
 
   @doc """
@@ -235,19 +235,19 @@ defmodule AWS.DataPipeline do
   does not need to call `SetTaskStatus` for tasks that are canceled by the
   web service during a call to `ReportTaskProgress`.
   """
-  def set_task_status(client, input, options \\ []) do
-    request(client, "SetTaskStatus", input, options)
+  def set_task_status(client, input, http_options \\ []) do
+    request(client, "SetTaskStatus", input, http_options)
   end
 
   @doc """
   Validates the specified pipeline definition to ensure that it is well
   formed and can be run without error.
   """
-  def validate_pipeline_definition(client, input, options \\ []) do
-    request(client, "ValidatePipelineDefinition", input, options)
+  def validate_pipeline_definition(client, input, http_options \\ []) do
+    request(client, "ValidatePipelineDefinition", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "datapipeline"}
     host = "datapipeline.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -256,12 +256,12 @@ defmodule AWS.DataPipeline do
                {"X-Amz-Target", "DataPipeline.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/device_farm.ex
+++ b/lib/aws/device_farm.ex
@@ -11,180 +11,180 @@ defmodule AWS.DeviceFarm do
   @doc """
   Creates a device pool.
   """
-  def create_device_pool(client, input, options \\ []) do
-    request(client, "CreateDevicePool", input, options)
+  def create_device_pool(client, input, http_options \\ []) do
+    request(client, "CreateDevicePool", input, http_options)
   end
 
   @doc """
   Creates a new project.
   """
-  def create_project(client, input, options \\ []) do
-    request(client, "CreateProject", input, options)
+  def create_project(client, input, http_options \\ []) do
+    request(client, "CreateProject", input, http_options)
   end
 
   @doc """
   Uploads an app or test scripts.
   """
-  def create_upload(client, input, options \\ []) do
-    request(client, "CreateUpload", input, options)
+  def create_upload(client, input, http_options \\ []) do
+    request(client, "CreateUpload", input, http_options)
   end
 
   @doc """
   Returns the number of unmetered iOS and/or unmetered Android devices that
   have been purchased by the account.
   """
-  def get_account_settings(client, input, options \\ []) do
-    request(client, "GetAccountSettings", input, options)
+  def get_account_settings(client, input, http_options \\ []) do
+    request(client, "GetAccountSettings", input, http_options)
   end
 
   @doc """
   Gets information about a unique device type.
   """
-  def get_device(client, input, options \\ []) do
-    request(client, "GetDevice", input, options)
+  def get_device(client, input, http_options \\ []) do
+    request(client, "GetDevice", input, http_options)
   end
 
   @doc """
   Gets information about a device pool.
   """
-  def get_device_pool(client, input, options \\ []) do
-    request(client, "GetDevicePool", input, options)
+  def get_device_pool(client, input, http_options \\ []) do
+    request(client, "GetDevicePool", input, http_options)
   end
 
   @doc """
   Gets information about compatibility with a device pool.
   """
-  def get_device_pool_compatibility(client, input, options \\ []) do
-    request(client, "GetDevicePoolCompatibility", input, options)
+  def get_device_pool_compatibility(client, input, http_options \\ []) do
+    request(client, "GetDevicePoolCompatibility", input, http_options)
   end
 
   @doc """
   Gets information about a job.
   """
-  def get_job(client, input, options \\ []) do
-    request(client, "GetJob", input, options)
+  def get_job(client, input, http_options \\ []) do
+    request(client, "GetJob", input, http_options)
   end
 
   @doc """
   Gets information about a project.
   """
-  def get_project(client, input, options \\ []) do
-    request(client, "GetProject", input, options)
+  def get_project(client, input, http_options \\ []) do
+    request(client, "GetProject", input, http_options)
   end
 
   @doc """
   Gets information about a run.
   """
-  def get_run(client, input, options \\ []) do
-    request(client, "GetRun", input, options)
+  def get_run(client, input, http_options \\ []) do
+    request(client, "GetRun", input, http_options)
   end
 
   @doc """
   Gets information about a suite.
   """
-  def get_suite(client, input, options \\ []) do
-    request(client, "GetSuite", input, options)
+  def get_suite(client, input, http_options \\ []) do
+    request(client, "GetSuite", input, http_options)
   end
 
   @doc """
   Gets information about a test.
   """
-  def get_test(client, input, options \\ []) do
-    request(client, "GetTest", input, options)
+  def get_test(client, input, http_options \\ []) do
+    request(client, "GetTest", input, http_options)
   end
 
   @doc """
   Gets information about an upload.
   """
-  def get_upload(client, input, options \\ []) do
-    request(client, "GetUpload", input, options)
+  def get_upload(client, input, http_options \\ []) do
+    request(client, "GetUpload", input, http_options)
   end
 
   @doc """
   Gets information about artifacts.
   """
-  def list_artifacts(client, input, options \\ []) do
-    request(client, "ListArtifacts", input, options)
+  def list_artifacts(client, input, http_options \\ []) do
+    request(client, "ListArtifacts", input, http_options)
   end
 
   @doc """
   Gets information about device pools.
   """
-  def list_device_pools(client, input, options \\ []) do
-    request(client, "ListDevicePools", input, options)
+  def list_device_pools(client, input, http_options \\ []) do
+    request(client, "ListDevicePools", input, http_options)
   end
 
   @doc """
   Gets information about unique device types.
   """
-  def list_devices(client, input, options \\ []) do
-    request(client, "ListDevices", input, options)
+  def list_devices(client, input, http_options \\ []) do
+    request(client, "ListDevices", input, http_options)
   end
 
   @doc """
   Gets information about jobs.
   """
-  def list_jobs(client, input, options \\ []) do
-    request(client, "ListJobs", input, options)
+  def list_jobs(client, input, http_options \\ []) do
+    request(client, "ListJobs", input, http_options)
   end
 
   @doc """
   Gets information about projects.
   """
-  def list_projects(client, input, options \\ []) do
-    request(client, "ListProjects", input, options)
+  def list_projects(client, input, http_options \\ []) do
+    request(client, "ListProjects", input, http_options)
   end
 
   @doc """
   Gets information about runs.
   """
-  def list_runs(client, input, options \\ []) do
-    request(client, "ListRuns", input, options)
+  def list_runs(client, input, http_options \\ []) do
+    request(client, "ListRuns", input, http_options)
   end
 
   @doc """
   Gets information about samples.
   """
-  def list_samples(client, input, options \\ []) do
-    request(client, "ListSamples", input, options)
+  def list_samples(client, input, http_options \\ []) do
+    request(client, "ListSamples", input, http_options)
   end
 
   @doc """
   Gets information about suites.
   """
-  def list_suites(client, input, options \\ []) do
-    request(client, "ListSuites", input, options)
+  def list_suites(client, input, http_options \\ []) do
+    request(client, "ListSuites", input, http_options)
   end
 
   @doc """
   Gets information about tests.
   """
-  def list_tests(client, input, options \\ []) do
-    request(client, "ListTests", input, options)
+  def list_tests(client, input, http_options \\ []) do
+    request(client, "ListTests", input, http_options)
   end
 
   @doc """
   Gets information about unique problems.
   """
-  def list_unique_problems(client, input, options \\ []) do
-    request(client, "ListUniqueProblems", input, options)
+  def list_unique_problems(client, input, http_options \\ []) do
+    request(client, "ListUniqueProblems", input, http_options)
   end
 
   @doc """
   Gets information about uploads.
   """
-  def list_uploads(client, input, options \\ []) do
-    request(client, "ListUploads", input, options)
+  def list_uploads(client, input, http_options \\ []) do
+    request(client, "ListUploads", input, http_options)
   end
 
   @doc """
   Schedules a run.
   """
-  def schedule_run(client, input, options \\ []) do
-    request(client, "ScheduleRun", input, options)
+  def schedule_run(client, input, http_options \\ []) do
+    request(client, "ScheduleRun", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "devicefarm"}
     host = "devicefarm.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -193,12 +193,12 @@ defmodule AWS.DeviceFarm do
                {"X-Amz-Target", "DeviceFarm_20150623.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/direct_connect.ex
+++ b/lib/aws/direct_connect.ex
@@ -33,8 +33,8 @@ defmodule AWS.DirectConnect do
   Allocates a VLAN number and a specified amount of bandwidth for use by a
   hosted connection on the given interconnect.
   """
-  def allocate_connection_on_interconnect(client, input, options \\ []) do
-    request(client, "AllocateConnectionOnInterconnect", input, options)
+  def allocate_connection_on_interconnect(client, input, http_options \\ []) do
+    request(client, "AllocateConnectionOnInterconnect", input, http_options)
   end
 
   @doc """
@@ -48,8 +48,8 @@ defmodule AWS.DirectConnect do
   this step has been completed, the virtual interface will be in 'Confirming'
   state, and will not be available for handling traffic.
   """
-  def allocate_private_virtual_interface(client, input, options \\ []) do
-    request(client, "AllocatePrivateVirtualInterface", input, options)
+  def allocate_private_virtual_interface(client, input, http_options \\ []) do
+    request(client, "AllocatePrivateVirtualInterface", input, http_options)
   end
 
   @doc """
@@ -63,8 +63,8 @@ defmodule AWS.DirectConnect do
   this step has been completed, the virtual interface will be in 'Confirming'
   state, and will not be available for handling traffic.
   """
-  def allocate_public_virtual_interface(client, input, options \\ []) do
-    request(client, "AllocatePublicVirtualInterface", input, options)
+  def allocate_public_virtual_interface(client, input, http_options \\ []) do
+    request(client, "AllocatePublicVirtualInterface", input, http_options)
   end
 
   @doc """
@@ -74,8 +74,8 @@ defmodule AWS.DirectConnect do
   and will remain in this state until the owner calls ConfirmConnection to
   confirm creation of the hosted connection.
   """
-  def confirm_connection(client, input, options \\ []) do
-    request(client, "ConfirmConnection", input, options)
+  def confirm_connection(client, input, http_options \\ []) do
+    request(client, "ConfirmConnection", input, http_options)
   end
 
   @doc """
@@ -86,8 +86,8 @@ defmodule AWS.DirectConnect do
   interface will be created and attached to the given virtual private
   gateway, and will be available for handling traffic.
   """
-  def confirm_private_virtual_interface(client, input, options \\ []) do
-    request(client, "ConfirmPrivateVirtualInterface", input, options)
+  def confirm_private_virtual_interface(client, input, http_options \\ []) do
+    request(client, "ConfirmPrivateVirtualInterface", input, http_options)
   end
 
   @doc """
@@ -96,8 +96,8 @@ defmodule AWS.DirectConnect do
   After the virtual interface owner calls this function, the specified
   virtual interface will be created and made available for handling traffic.
   """
-  def confirm_public_virtual_interface(client, input, options \\ []) do
-    request(client, "ConfirmPublicVirtualInterface", input, options)
+  def confirm_public_virtual_interface(client, input, http_options \\ []) do
+    request(client, "ConfirmPublicVirtualInterface", input, http_options)
   end
 
   @doc """
@@ -112,8 +112,8 @@ defmodule AWS.DirectConnect do
   connections with AWS Direct Connect locations in multiple regions, but a
   connection in one region does not provide connectivity to other regions.
   """
-  def create_connection(client, input, options \\ []) do
-    request(client, "CreateConnection", input, options)
+  def create_connection(client, input, http_options \\ []) do
+    request(client, "CreateConnection", input, http_options)
   end
 
   @doc """
@@ -135,8 +135,8 @@ defmodule AWS.DirectConnect do
   resources by creating a virtual interface on their connection, using the
   VLAN assigned to them by the AWS Direct Connect partner.
   """
-  def create_interconnect(client, input, options \\ []) do
-    request(client, "CreateInterconnect", input, options)
+  def create_interconnect(client, input, http_options \\ []) do
+    request(client, "CreateInterconnect", input, http_options)
   end
 
   @doc """
@@ -144,8 +144,8 @@ defmodule AWS.DirectConnect do
   that transports AWS Direct Connect traffic. A private virtual interface
   supports sending traffic to a single virtual private cloud (VPC).
   """
-  def create_private_virtual_interface(client, input, options \\ []) do
-    request(client, "CreatePrivateVirtualInterface", input, options)
+  def create_private_virtual_interface(client, input, http_options \\ []) do
+    request(client, "CreatePrivateVirtualInterface", input, http_options)
   end
 
   @doc """
@@ -154,8 +154,8 @@ defmodule AWS.DirectConnect do
   supports sending traffic to public services of AWS such as Amazon Simple
   Storage Service (Amazon S3).
   """
-  def create_public_virtual_interface(client, input, options \\ []) do
-    request(client, "CreatePublicVirtualInterface", input, options)
+  def create_public_virtual_interface(client, input, http_options \\ []) do
+    request(client, "CreatePublicVirtualInterface", input, http_options)
   end
 
   @doc """
@@ -166,22 +166,22 @@ defmodule AWS.DirectConnect do
   services or charges for cross-connects or network circuits that connect you
   to the AWS Direct Connect location.
   """
-  def delete_connection(client, input, options \\ []) do
-    request(client, "DeleteConnection", input, options)
+  def delete_connection(client, input, http_options \\ []) do
+    request(client, "DeleteConnection", input, http_options)
   end
 
   @doc """
   Deletes the specified interconnect.
   """
-  def delete_interconnect(client, input, options \\ []) do
-    request(client, "DeleteInterconnect", input, options)
+  def delete_interconnect(client, input, http_options \\ []) do
+    request(client, "DeleteInterconnect", input, http_options)
   end
 
   @doc """
   Deletes a virtual interface.
   """
-  def delete_virtual_interface(client, input, options \\ []) do
-    request(client, "DeleteVirtualInterface", input, options)
+  def delete_virtual_interface(client, input, http_options \\ []) do
+    request(client, "DeleteVirtualInterface", input, http_options)
   end
 
   @doc """
@@ -190,16 +190,16 @@ defmodule AWS.DirectConnect do
   If a connection ID is provided, the call returns only that particular
   connection.
   """
-  def describe_connections(client, input, options \\ []) do
-    request(client, "DescribeConnections", input, options)
+  def describe_connections(client, input, http_options \\ []) do
+    request(client, "DescribeConnections", input, http_options)
   end
 
   @doc """
   Return a list of connections that have been provisioned on the given
   interconnect.
   """
-  def describe_connections_on_interconnect(client, input, options \\ []) do
-    request(client, "DescribeConnectionsOnInterconnect", input, options)
+  def describe_connections_on_interconnect(client, input, http_options \\ []) do
+    request(client, "DescribeConnectionsOnInterconnect", input, http_options)
   end
 
   @doc """
@@ -208,8 +208,8 @@ defmodule AWS.DirectConnect do
   If an interconnect ID is provided, it will only return this particular
   interconnect.
   """
-  def describe_interconnects(client, input, options \\ []) do
-    request(client, "DescribeInterconnects", input, options)
+  def describe_interconnects(client, input, http_options \\ []) do
+    request(client, "DescribeInterconnects", input, http_options)
   end
 
   @doc """
@@ -217,8 +217,8 @@ defmodule AWS.DirectConnect do
   These are the locations that may be selected when calling CreateConnection
   or CreateInterconnect.
   """
-  def describe_locations(client, input, options \\ []) do
-    request(client, "DescribeLocations", input, options)
+  def describe_locations(client, input, http_options \\ []) do
+    request(client, "DescribeLocations", input, http_options)
   end
 
   @doc """
@@ -230,8 +230,8 @@ defmodule AWS.DirectConnect do
   CreateVpnGateway](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVpnGateway.html)
   action.
   """
-  def describe_virtual_gateways(client, input, options \\ []) do
-    request(client, "DescribeVirtualGateways", input, options)
+  def describe_virtual_gateways(client, input, http_options \\ []) do
+    request(client, "DescribeVirtualGateways", input, http_options)
   end
 
   @doc """
@@ -249,11 +249,11 @@ defmodule AWS.DirectConnect do
   specified connection will be returned. If a virtual interface ID is
   provided, only this particular virtual interface will be returned.
   """
-  def describe_virtual_interfaces(client, input, options \\ []) do
-    request(client, "DescribeVirtualInterfaces", input, options)
+  def describe_virtual_interfaces(client, input, http_options \\ []) do
+    request(client, "DescribeVirtualInterfaces", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "directconnect"}
     host = "directconnect.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -262,12 +262,12 @@ defmodule AWS.DirectConnect do
                {"X-Amz-Target", "OvertureService.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/directory_service.ex
+++ b/lib/aws/directory_service.ex
@@ -13,8 +13,8 @@ defmodule AWS.DirectoryService do
   @doc """
   Creates an AD Connector to connect an on-premises directory.
   """
-  def connect_directory(client, input, options \\ []) do
-    request(client, "ConnectDirectory", input, options)
+  def connect_directory(client, input, http_options \\ []) do
+    request(client, "ConnectDirectory", input, http_options)
   end
 
   @doc """
@@ -27,23 +27,23 @@ defmodule AWS.DirectoryService do
 
   </important>
   """
-  def create_alias(client, input, options \\ []) do
-    request(client, "CreateAlias", input, options)
+  def create_alias(client, input, http_options \\ []) do
+    request(client, "CreateAlias", input, http_options)
   end
 
   @doc """
   Creates a computer account in the specified directory, and joins the
   computer to the directory.
   """
-  def create_computer(client, input, options \\ []) do
-    request(client, "CreateComputer", input, options)
+  def create_computer(client, input, http_options \\ []) do
+    request(client, "CreateComputer", input, http_options)
   end
 
   @doc """
   Creates a Simple AD directory.
   """
-  def create_directory(client, input, options \\ []) do
-    request(client, "CreateDirectory", input, options)
+  def create_directory(client, input, http_options \\ []) do
+    request(client, "CreateDirectory", input, http_options)
   end
 
   @doc """
@@ -51,22 +51,22 @@ defmodule AWS.DirectoryService do
 
   You cannot take snapshots of extended or connected directories.
   """
-  def create_snapshot(client, input, options \\ []) do
-    request(client, "CreateSnapshot", input, options)
+  def create_snapshot(client, input, http_options \\ []) do
+    request(client, "CreateSnapshot", input, http_options)
   end
 
   @doc """
   Deletes an AWS Directory Service directory.
   """
-  def delete_directory(client, input, options \\ []) do
-    request(client, "DeleteDirectory", input, options)
+  def delete_directory(client, input, http_options \\ []) do
+    request(client, "DeleteDirectory", input, http_options)
   end
 
   @doc """
   Deletes a directory snapshot.
   """
-  def delete_snapshot(client, input, options \\ []) do
-    request(client, "DeleteSnapshot", input, options)
+  def delete_snapshot(client, input, http_options \\ []) do
+    request(client, "DeleteSnapshot", input, http_options)
   end
 
   @doc """
@@ -85,8 +85,8 @@ defmodule AWS.DirectoryService do
   You can also specify a maximum number of return results with the *Limit*
   parameter.
   """
-  def describe_directories(client, input, options \\ []) do
-    request(client, "DescribeDirectories", input, options)
+  def describe_directories(client, input, http_options \\ []) do
+    request(client, "DescribeDirectories", input, http_options)
   end
 
   @doc """
@@ -101,52 +101,52 @@ defmodule AWS.DirectoryService do
   You can also specify a maximum number of return results with the *Limit*
   parameter.
   """
-  def describe_snapshots(client, input, options \\ []) do
-    request(client, "DescribeSnapshots", input, options)
+  def describe_snapshots(client, input, http_options \\ []) do
+    request(client, "DescribeSnapshots", input, http_options)
   end
 
   @doc """
   Disables multi-factor authentication (MFA) with Remote Authentication Dial
   In User Service (RADIUS) for an AD Connector directory.
   """
-  def disable_radius(client, input, options \\ []) do
-    request(client, "DisableRadius", input, options)
+  def disable_radius(client, input, http_options \\ []) do
+    request(client, "DisableRadius", input, http_options)
   end
 
   @doc """
   Disables single-sign on for a directory.
   """
-  def disable_sso(client, input, options \\ []) do
-    request(client, "DisableSso", input, options)
+  def disable_sso(client, input, http_options \\ []) do
+    request(client, "DisableSso", input, http_options)
   end
 
   @doc """
   Enables multi-factor authentication (MFA) with Remote Authentication Dial
   In User Service (RADIUS) for an AD Connector directory.
   """
-  def enable_radius(client, input, options \\ []) do
-    request(client, "EnableRadius", input, options)
+  def enable_radius(client, input, http_options \\ []) do
+    request(client, "EnableRadius", input, http_options)
   end
 
   @doc """
   Enables single-sign on for a directory.
   """
-  def enable_sso(client, input, options \\ []) do
-    request(client, "EnableSso", input, options)
+  def enable_sso(client, input, http_options \\ []) do
+    request(client, "EnableSso", input, http_options)
   end
 
   @doc """
   Obtains directory limit information for the current region.
   """
-  def get_directory_limits(client, input, options \\ []) do
-    request(client, "GetDirectoryLimits", input, options)
+  def get_directory_limits(client, input, http_options \\ []) do
+    request(client, "GetDirectoryLimits", input, http_options)
   end
 
   @doc """
   Obtains the manual snapshot limits for a directory.
   """
-  def get_snapshot_limits(client, input, options \\ []) do
-    request(client, "GetSnapshotLimits", input, options)
+  def get_snapshot_limits(client, input, http_options \\ []) do
+    request(client, "GetSnapshotLimits", input, http_options)
   end
 
   @doc """
@@ -161,19 +161,19 @@ defmodule AWS.DirectoryService do
   **DirectoryDescription.Stage** value changes to `Active`, the restore
   operation is complete.
   """
-  def restore_from_snapshot(client, input, options \\ []) do
-    request(client, "RestoreFromSnapshot", input, options)
+  def restore_from_snapshot(client, input, http_options \\ []) do
+    request(client, "RestoreFromSnapshot", input, http_options)
   end
 
   @doc """
   Updates the Remote Authentication Dial In User Service (RADIUS) server
   information for an AD Connector directory.
   """
-  def update_radius(client, input, options \\ []) do
-    request(client, "UpdateRadius", input, options)
+  def update_radius(client, input, http_options \\ []) do
+    request(client, "UpdateRadius", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "ds"}
     host = "ds.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -182,12 +182,12 @@ defmodule AWS.DirectoryService do
                {"X-Amz-Target", "DirectoryService_20150416.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/dynamodb.ex
+++ b/lib/aws/dynamodb.ex
@@ -179,8 +179,8 @@ defmodule AWS.DynamoDB do
   Calculations](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#CapacityUnitCalculations)
   in the *Amazon DynamoDB Developer Guide*.
   """
-  def batch_get_item(client, input, options \\ []) do
-    request(client, "BatchGetItem", input, options)
+  def batch_get_item(client, input, http_options \\ []) do
+    request(client, "BatchGetItem", input, http_options)
   end
 
   @doc """
@@ -261,8 +261,8 @@ defmodule AWS.DynamoDB do
 
   </li> </ul>
   """
-  def batch_write_item(client, input, options \\ []) do
-    request(client, "BatchWriteItem", input, options)
+  def batch_write_item(client, input, http_options \\ []) do
+    request(client, "BatchWriteItem", input, http_options)
   end
 
   @doc """
@@ -285,8 +285,8 @@ defmodule AWS.DynamoDB do
 
   You can use the *DescribeTable* API to check the table status.
   """
-  def create_table(client, input, options \\ []) do
-    request(client, "CreateTable", input, options)
+  def create_table(client, input, http_options \\ []) do
+    request(client, "CreateTable", input, http_options)
   end
 
   @doc """
@@ -305,8 +305,8 @@ defmodule AWS.DynamoDB do
   conditions are met. If those conditions are met, DynamoDB performs the
   delete. Otherwise, the item is not deleted.
   """
-  def delete_item(client, input, options \\ []) do
-    request(client, "DeleteItem", input, options)
+  def delete_item(client, input, http_options \\ []) do
+    request(client, "DeleteItem", input, http_options)
   end
 
   @doc """
@@ -331,8 +331,8 @@ defmodule AWS.DynamoDB do
 
   Use the *DescribeTable* API to check the status of the table.
   """
-  def delete_table(client, input, options \\ []) do
-    request(client, "DeleteTable", input, options)
+  def delete_table(client, input, http_options \\ []) do
+    request(client, "DeleteTable", input, http_options)
   end
 
   @doc """
@@ -348,8 +348,8 @@ defmodule AWS.DynamoDB do
 
   </note>
   """
-  def describe_table(client, input, options \\ []) do
-    request(client, "DescribeTable", input, options)
+  def describe_table(client, input, http_options \\ []) do
+    request(client, "DescribeTable", input, http_options)
   end
 
   @doc """
@@ -362,8 +362,8 @@ defmodule AWS.DynamoDB do
   `true`. Although a strongly consistent read might take more time than an
   eventually consistent read, it always returns the last updated value.
   """
-  def get_item(client, input, options \\ []) do
-    request(client, "GetItem", input, options)
+  def get_item(client, input, http_options \\ []) do
+    request(client, "GetItem", input, http_options)
   end
 
   @doc """
@@ -371,8 +371,8 @@ defmodule AWS.DynamoDB do
   endpoint. The output from *ListTables* is paginated, with each page
   returning a maximum of 100 table names.
   """
-  def list_tables(client, input, options \\ []) do
-    request(client, "ListTables", input, options)
+  def list_tables(client, input, http_options \\ []) do
+    request(client, "ListTables", input, http_options)
   end
 
   @doc """
@@ -404,8 +404,8 @@ defmodule AWS.DynamoDB do
   Items](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithItems.html)
   in the *Amazon DynamoDB Developer Guide*.
   """
-  def put_item(client, input, options \\ []) do
-    request(client, "PutItem", input, options)
+  def put_item(client, input, http_options \\ []) do
+    request(client, "PutItem", input, http_options)
   end
 
   @doc """
@@ -436,8 +436,8 @@ defmodule AWS.DynamoDB do
   result. Global secondary indexes support eventually consistent reads only,
   so do not specify *ConsistentRead* when querying a global secondary index.
   """
-  def query(client, input, options \\ []) do
-    request(client, "Query", input, options)
+  def query(client, input, http_options \\ []) do
+    request(client, "Query", input, http_options)
   end
 
   @doc """
@@ -463,8 +463,8 @@ defmodule AWS.DynamoDB do
   consistent reads instead by setting the *ConsistentRead* parameter to
   *true*.
   """
-  def scan(client, input, options \\ []) do
-    request(client, "Scan", input, options)
+  def scan(client, input, http_options \\ []) do
+    request(client, "Scan", input, http_options)
   end
 
   @doc """
@@ -479,8 +479,8 @@ defmodule AWS.DynamoDB do
   You can also return the item's attribute values in the same *UpdateItem*
   operation using the *ReturnValues* parameter.
   """
-  def update_item(client, input, options \\ []) do
-    request(client, "UpdateItem", input, options)
+  def update_item(client, input, http_options \\ []) do
+    request(client, "UpdateItem", input, http_options)
   end
 
   @doc """
@@ -504,11 +504,11 @@ defmodule AWS.DynamoDB do
   table returns to the `ACTIVE` state, the *UpdateTable* operation is
   complete.
   """
-  def update_table(client, input, options \\ []) do
-    request(client, "UpdateTable", input, options)
+  def update_table(client, input, http_options \\ []) do
+    request(client, "UpdateTable", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "dynamodb"}
     host = "dynamodb.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -517,12 +517,12 @@ defmodule AWS.DynamoDB do
                {"X-Amz-Target", "DynamoDB_20120810.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/dynamodb_streams.ex
+++ b/lib/aws/dynamodb_streams.ex
@@ -52,8 +52,8 @@ defmodule AWS.DynamoDB.Streams do
   `EndingSequenceNumber` are present, the that shared is closed and can no
   longer receive more data.
   """
-  def describe_stream(client, input, options \\ []) do
-    request(client, "DescribeStream", input, options)
+  def describe_stream(client, input, http_options \\ []) do
+    request(client, "DescribeStream", input, http_options)
   end
 
   @doc """
@@ -71,8 +71,8 @@ defmodule AWS.DynamoDB.Streams do
 
   </note>
   """
-  def get_records(client, input, options \\ []) do
-    request(client, "GetRecords", input, options)
+  def get_records(client, input, http_options \\ []) do
+    request(client, "GetRecords", input, http_options)
   end
 
   @doc """
@@ -86,8 +86,8 @@ defmodule AWS.DynamoDB.Streams do
 
   </note>
   """
-  def get_shard_iterator(client, input, options \\ []) do
-    request(client, "GetShardIterator", input, options)
+  def get_shard_iterator(client, input, http_options \\ []) do
+    request(client, "GetShardIterator", input, http_options)
   end
 
   @doc """
@@ -99,11 +99,11 @@ defmodule AWS.DynamoDB.Streams do
 
   </note>
   """
-  def list_streams(client, input, options \\ []) do
-    request(client, "ListStreams", input, options)
+  def list_streams(client, input, http_options \\ []) do
+    request(client, "ListStreams", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "streams.dynamodb"}
     host = "streams.dynamodb.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -112,12 +112,12 @@ defmodule AWS.DynamoDB.Streams do
                {"X-Amz-Target", "DynamoDBStreams_20120810.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/ecs.ex
+++ b/lib/aws/ecs.ex
@@ -24,8 +24,8 @@ defmodule AWS.ECS do
   you can create your own cluster with a unique name with the `CreateCluster`
   action.
   """
-  def create_cluster(client, input, options \\ []) do
-    request(client, "CreateCluster", input, options)
+  def create_cluster(client, input, http_options \\ []) do
+    request(client, "CreateCluster", input, http_options)
   end
 
   @doc """
@@ -34,8 +34,8 @@ defmodule AWS.ECS do
   `desiredCount`, Amazon ECS will spawn another instantiation of the task in
   the specified cluster.
   """
-  def create_service(client, input, options \\ []) do
-    request(client, "CreateService", input, options)
+  def create_service(client, input, http_options \\ []) do
+    request(client, "CreateService", input, http_options)
   end
 
   @doc """
@@ -44,15 +44,15 @@ defmodule AWS.ECS do
   instances in a cluster with `ListContainerInstances` and deregister them
   with `DeregisterContainerInstance`.
   """
-  def delete_cluster(client, input, options \\ []) do
-    request(client, "DeleteCluster", input, options)
+  def delete_cluster(client, input, http_options \\ []) do
+    request(client, "DeleteCluster", input, http_options)
   end
 
   @doc """
   Deletes a specified service within a cluster.
   """
-  def delete_service(client, input, options \\ []) do
-    request(client, "DeleteService", input, options)
+  def delete_service(client, input, http_options \\ []) do
+    request(client, "DeleteService", input, http_options)
   end
 
   @doc """
@@ -74,8 +74,8 @@ defmodule AWS.ECS do
 
   </note>
   """
-  def deregister_container_instance(client, input, options \\ []) do
-    request(client, "DeregisterContainerInstance", input, options)
+  def deregister_container_instance(client, input, http_options \\ []) do
+    request(client, "DeregisterContainerInstance", input, http_options)
   end
 
   @doc """
@@ -92,15 +92,15 @@ defmodule AWS.ECS do
   following deregistration where these restrictions have not yet taken
   effect).
   """
-  def deregister_task_definition(client, input, options \\ []) do
-    request(client, "DeregisterTaskDefinition", input, options)
+  def deregister_task_definition(client, input, http_options \\ []) do
+    request(client, "DeregisterTaskDefinition", input, http_options)
   end
 
   @doc """
   Describes one or more of your clusters.
   """
-  def describe_clusters(client, input, options \\ []) do
-    request(client, "DescribeClusters", input, options)
+  def describe_clusters(client, input, http_options \\ []) do
+    request(client, "DescribeClusters", input, http_options)
   end
 
   @doc """
@@ -108,15 +108,15 @@ defmodule AWS.ECS do
   metadata about registered and remaining resources on each container
   instance requested.
   """
-  def describe_container_instances(client, input, options \\ []) do
-    request(client, "DescribeContainerInstances", input, options)
+  def describe_container_instances(client, input, http_options \\ []) do
+    request(client, "DescribeContainerInstances", input, http_options)
   end
 
   @doc """
   Describes the specified services running in your cluster.
   """
-  def describe_services(client, input, options \\ []) do
-    request(client, "DescribeServices", input, options)
+  def describe_services(client, input, http_options \\ []) do
+    request(client, "DescribeServices", input, http_options)
   end
 
   @doc """
@@ -129,15 +129,15 @@ defmodule AWS.ECS do
 
   </note>
   """
-  def describe_task_definition(client, input, options \\ []) do
-    request(client, "DescribeTaskDefinition", input, options)
+  def describe_task_definition(client, input, http_options \\ []) do
+    request(client, "DescribeTaskDefinition", input, http_options)
   end
 
   @doc """
   Describes a specified task or tasks.
   """
-  def describe_tasks(client, input, options \\ []) do
-    request(client, "DescribeTasks", input, options)
+  def describe_tasks(client, input, http_options \\ []) do
+    request(client, "DescribeTasks", input, http_options)
   end
 
   @doc """
@@ -147,29 +147,29 @@ defmodule AWS.ECS do
   </note> Returns an endpoint for the Amazon EC2 Container Service agent to
   poll for updates.
   """
-  def discover_poll_endpoint(client, input, options \\ []) do
-    request(client, "DiscoverPollEndpoint", input, options)
+  def discover_poll_endpoint(client, input, http_options \\ []) do
+    request(client, "DiscoverPollEndpoint", input, http_options)
   end
 
   @doc """
   Returns a list of existing clusters.
   """
-  def list_clusters(client, input, options \\ []) do
-    request(client, "ListClusters", input, options)
+  def list_clusters(client, input, http_options \\ []) do
+    request(client, "ListClusters", input, http_options)
   end
 
   @doc """
   Returns a list of container instances in a specified cluster.
   """
-  def list_container_instances(client, input, options \\ []) do
-    request(client, "ListContainerInstances", input, options)
+  def list_container_instances(client, input, http_options \\ []) do
+    request(client, "ListContainerInstances", input, http_options)
   end
 
   @doc """
   Lists the services that are running in a specified cluster.
   """
-  def list_services(client, input, options \\ []) do
-    request(client, "ListServices", input, options)
+  def list_services(client, input, http_options \\ []) do
+    request(client, "ListServices", input, http_options)
   end
 
   @doc """
@@ -178,8 +178,8 @@ defmodule AWS.ECS do
   `ACTIVE` task definitions). You can filter the results with the
   `familyPrefix` parameter.
   """
-  def list_task_definition_families(client, input, options \\ []) do
-    request(client, "ListTaskDefinitionFamilies", input, options)
+  def list_task_definition_families(client, input, http_options \\ []) do
+    request(client, "ListTaskDefinitionFamilies", input, http_options)
   end
 
   @doc """
@@ -187,8 +187,8 @@ defmodule AWS.ECS do
   can filter the results by family name with the `familyPrefix` parameter or
   by status with the `status` parameter.
   """
-  def list_task_definitions(client, input, options \\ []) do
-    request(client, "ListTaskDefinitions", input, options)
+  def list_task_definitions(client, input, http_options \\ []) do
+    request(client, "ListTaskDefinitions", input, http_options)
   end
 
   @doc """
@@ -197,8 +197,8 @@ defmodule AWS.ECS do
   status of the task with the `family`, `containerInstance`, and
   `desiredStatus` parameters.
   """
-  def list_tasks(client, input, options \\ []) do
-    request(client, "ListTasks", input, options)
+  def list_tasks(client, input, http_options \\ []) do
+    request(client, "ListTasks", input, http_options)
   end
 
   @doc """
@@ -208,8 +208,8 @@ defmodule AWS.ECS do
   </note> Registers an Amazon EC2 instance into the specified cluster. This
   instance will become available to place containers on.
   """
-  def register_container_instance(client, input, options \\ []) do
-    request(client, "RegisterContainerInstance", input, options)
+  def register_container_instance(client, input, http_options \\ []) do
+    request(client, "RegisterContainerInstance", input, http_options)
   end
 
   @doc """
@@ -220,8 +220,8 @@ defmodule AWS.ECS do
   Definitions](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html)
   in the *Amazon EC2 Container Service Developer Guide*.
   """
-  def register_task_definition(client, input, options \\ []) do
-    request(client, "RegisterTaskDefinition", input, options)
+  def register_task_definition(client, input, http_options \\ []) do
+    request(client, "RegisterTaskDefinition", input, http_options)
   end
 
   @doc """
@@ -233,8 +233,8 @@ defmodule AWS.ECS do
 
   </important>
   """
-  def run_task(client, input, options \\ []) do
-    request(client, "RunTask", input, options)
+  def run_task(client, input, http_options \\ []) do
+    request(client, "RunTask", input, http_options)
   end
 
   @doc """
@@ -247,15 +247,15 @@ defmodule AWS.ECS do
 
   </important>
   """
-  def start_task(client, input, options \\ []) do
-    request(client, "StartTask", input, options)
+  def start_task(client, input, http_options \\ []) do
+    request(client, "StartTask", input, http_options)
   end
 
   @doc """
   Stops a running task.
   """
-  def stop_task(client, input, options \\ []) do
-    request(client, "StopTask", input, options)
+  def stop_task(client, input, http_options \\ []) do
+    request(client, "StopTask", input, http_options)
   end
 
   @doc """
@@ -264,8 +264,8 @@ defmodule AWS.ECS do
 
   </note> Sent to acknowledge that a container changed states.
   """
-  def submit_container_state_change(client, input, options \\ []) do
-    request(client, "SubmitContainerStateChange", input, options)
+  def submit_container_state_change(client, input, http_options \\ []) do
+    request(client, "SubmitContainerStateChange", input, http_options)
   end
 
   @doc """
@@ -274,8 +274,8 @@ defmodule AWS.ECS do
 
   </note> Sent to acknowledge that a task changed states.
   """
-  def submit_task_state_change(client, input, options \\ []) do
-    request(client, "SubmitTaskStateChange", input, options)
+  def submit_task_state_change(client, input, http_options \\ []) do
+    request(client, "SubmitTaskStateChange", input, http_options)
   end
 
   @doc """
@@ -292,8 +292,8 @@ defmodule AWS.ECS do
   Agent](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-update.html#manually_update_agent)
   in the *Amazon EC2 Container Service Developer Guide*.
   """
-  def update_container_agent(client, input, options \\ []) do
-    request(client, "UpdateContainerAgent", input, options)
+  def update_container_agent(client, input, http_options \\ []) do
+    request(client, "UpdateContainerAgent", input, http_options)
   end
 
   @doc """
@@ -314,11 +314,11 @@ defmodule AWS.ECS do
   service, you can reduce the desired count of your service by one before
   modifying the task definition.
   """
-  def update_service(client, input, options \\ []) do
-    request(client, "UpdateService", input, options)
+  def update_service(client, input, http_options \\ []) do
+    request(client, "UpdateService", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "ecs"}
     host = "ecs.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -327,12 +327,12 @@ defmodule AWS.ECS do
                {"X-Amz-Target", "AmazonEC2ContainerServiceV20141113.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/efs.ex
+++ b/lib/aws/efs.ex
@@ -42,10 +42,10 @@ defmodule AWS.EFS do
   This operation requires permission for the
   `elasticfilesystem:CreateFileSystem` action.
   """
-  def create_file_system(client, input, options \\ []) do
+  def create_file_system(client, input, http_options \\ []) do
     url = "/2015-02-01/file-systems"
     headers = []
-    request(client, :post, url, headers, input, options, 201)
+    request(client, :post, url, headers, input, http_options, 201)
   end
 
   @doc """
@@ -136,10 +136,10 @@ defmodule AWS.EFS do
   <li>`ec2:DescribeNetworkInterfaces`</li>
   <li>`ec2:CreateNetworkInterface`</li> </ul>
   """
-  def create_mount_target(client, input, options \\ []) do
+  def create_mount_target(client, input, http_options \\ []) do
     url = "/2015-02-01/mount-targets"
     headers = []
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -152,10 +152,10 @@ defmodule AWS.EFS do
   This operation requires permission for the `elasticfilesystem:CreateTags`
   action.
   """
-  def create_tags(client, file_system_id, input, options \\ []) do
+  def create_tags(client, file_system_id, input, http_options \\ []) do
     url = "/2015-02-01/create-tags/#{URI.encode(file_system_id)}"
     headers = []
-    request(client, :post, url, headers, input, options, 204)
+    request(client, :post, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -175,10 +175,10 @@ defmodule AWS.EFS do
   error.</note> This operation requires permission for the
   `elasticfilesystem:DeleteFileSystem` action.
   """
-  def delete_file_system(client, file_system_id, input, options \\ []) do
+  def delete_file_system(client, file_system_id, input, http_options \\ []) do
     url = "/2015-02-01/file-systems/#{URI.encode(file_system_id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -206,10 +206,10 @@ defmodule AWS.EFS do
 
   <ul> <li>`ec2:DeleteNetworkInterface`</li> </ul>
   """
-  def delete_mount_target(client, mount_target_id, input, options \\ []) do
+  def delete_mount_target(client, mount_target_id, input, http_options \\ []) do
     url = "/2015-02-01/mount-targets/#{URI.encode(mount_target_id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -222,10 +222,10 @@ defmodule AWS.EFS do
   This operation requires permission for the `elasticfilesystem:DeleteTags`
   action.
   """
-  def delete_tags(client, file_system_id, input, options \\ []) do
+  def delete_tags(client, file_system_id, input, http_options \\ []) do
     url = "/2015-02-01/delete-tags/#{URI.encode(file_system_id)}"
     headers = []
-    request(client, :post, url, headers, input, options, 204)
+    request(client, :post, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -257,10 +257,10 @@ defmodule AWS.EFS do
   This operation requires permission for the
   `elasticfilesystem:DescribeFileSystems` action.
   """
-  def describe_file_systems(client, options \\ []) do
+  def describe_file_systems(client, http_options \\ []) do
     url = "/2015-02-01/file-systems"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -275,10 +275,10 @@ defmodule AWS.EFS do
   `ec2:DescribeNetworkInterfaceAttribute` action on the mount target's
   network interface. </li> </ul>
   """
-  def describe_mount_target_security_groups(client, mount_target_id, options \\ []) do
+  def describe_mount_target_security_groups(client, mount_target_id, http_options \\ []) do
     url = "/2015-02-01/mount-targets/#{URI.encode(mount_target_id)}/security-groups"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -289,10 +289,10 @@ defmodule AWS.EFS do
   `elasticfilesystem:DescribeMountTargets` action on the file system
   `FileSystemId`.
   """
-  def describe_mount_targets(client, options \\ []) do
+  def describe_mount_targets(client, http_options \\ []) do
     url = "/2015-02-01/mount-targets"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -304,10 +304,10 @@ defmodule AWS.EFS do
   This operation requires permission for the `elasticfilesystem:DescribeTags`
   action.
   """
-  def describe_tags(client, file_system_id, options \\ []) do
+  def describe_tags(client, file_system_id, http_options \\ []) do
     url = "/2015-02-01/tags/#{URI.encode(file_system_id)}/"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -327,13 +327,13 @@ defmodule AWS.EFS do
   `ec2:ModifyNetworkInterfaceAttribute` action on the mount target's network
   interface. </li> </ul>
   """
-  def modify_mount_target_security_groups(client, mount_target_id, input, options \\ []) do
+  def modify_mount_target_security_groups(client, mount_target_id, input, http_options \\ []) do
     url = "/2015-02-01/mount-targets/#{URI.encode(mount_target_id)}/security-groups"
     headers = []
-    request(client, :put, url, headers, input, options, 204)
+    request(client, :put, url, headers, input, http_options, 204)
   end
 
-  defp request(client, method, url, headers, input, options, success_status_code) do
+  defp request(client, method, url, headers, input, http_options, success_status_code) do
     client = %{client | service: "elasticfilesystem"}
     host = "elasticfilesystem.#{client.region}.#{client.endpoint}"
     url = "https://#{host}#{url}"
@@ -342,32 +342,32 @@ defmodule AWS.EFS do
                           headers)
     payload = encode_payload(input)
     headers = AWS.Request.sign_v4(client, method, url, headers, payload)
-    perform_request(method, url, payload, headers, options, success_status_code)
+    perform_request(method, url, payload, headers, http_options, success_status_code)
   end
 
-  defp perform_request(method, url, payload, headers, options, nil) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, nil) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 202, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 204, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end
   end
 
-  defp perform_request(method, url, payload, headers, options, success_status_code) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, success_status_code) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/emr.ex
+++ b/lib/aws/emr.ex
@@ -13,8 +13,8 @@ defmodule AWS.EMR do
   @doc """
   AddInstanceGroups adds an instance group to a running cluster.
   """
-  def add_instance_groups(client, input, options \\ []) do
-    request(client, "AddInstanceGroups", input, options)
+  def add_instance_groups(client, input, http_options \\ []) do
+    request(client, "AddInstanceGroups", input, http_options)
   end
 
   @doc """
@@ -44,8 +44,8 @@ defmodule AWS.EMR do
   You can only add steps to a job flow that is in one of the following
   states: STARTING, BOOTSTRAPPING, RUNNING, or WAITING.
   """
-  def add_job_flow_steps(client, input, options \\ []) do
-    request(client, "AddJobFlowSteps", input, options)
+  def add_job_flow_steps(client, input, http_options \\ []) do
+    request(client, "AddJobFlowSteps", input, http_options)
   end
 
   @doc """
@@ -55,8 +55,8 @@ defmodule AWS.EMR do
   EMR
   Resources](http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-tags.html).
   """
-  def add_tags(client, input, options \\ []) do
-    request(client, "AddTags", input, options)
+  def add_tags(client, input, http_options \\ []) do
+    request(client, "AddTags", input, http_options)
   end
 
   @doc """
@@ -64,8 +64,8 @@ defmodule AWS.EMR do
   configuration, VPC settings, and so on. For information about the cluster
   steps, see `ListSteps`.
   """
-  def describe_cluster(client, input, options \\ []) do
-    request(client, "DescribeCluster", input, options)
+  def describe_cluster(client, input, http_options \\ []) do
+    request(client, "DescribeCluster", input, http_options)
   end
 
   @doc """
@@ -89,22 +89,22 @@ defmodule AWS.EMR do
   </ul> Amazon Elastic MapReduce can return a maximum of 512 job flow
   descriptions.
   """
-  def describe_job_flows(client, input, options \\ []) do
-    request(client, "DescribeJobFlows", input, options)
+  def describe_job_flows(client, input, http_options \\ []) do
+    request(client, "DescribeJobFlows", input, http_options)
   end
 
   @doc """
   Provides more detail about the cluster step.
   """
-  def describe_step(client, input, options \\ []) do
-    request(client, "DescribeStep", input, options)
+  def describe_step(client, input, http_options \\ []) do
+    request(client, "DescribeStep", input, http_options)
   end
 
   @doc """
   Provides information about the bootstrap actions associated with a cluster.
   """
-  def list_bootstrap_actions(client, input, options \\ []) do
-    request(client, "ListBootstrapActions", input, options)
+  def list_bootstrap_actions(client, input, http_options \\ []) do
+    request(client, "ListBootstrapActions", input, http_options)
   end
 
   @doc """
@@ -114,15 +114,15 @@ defmodule AWS.EMR do
   a maximum of 50 clusters per call, but returns a marker to track the paging
   of the cluster list across multiple ListClusters calls.
   """
-  def list_clusters(client, input, options \\ []) do
-    request(client, "ListClusters", input, options)
+  def list_clusters(client, input, http_options \\ []) do
+    request(client, "ListClusters", input, http_options)
   end
 
   @doc """
   Provides all available details about the instance groups in a cluster.
   """
-  def list_instance_groups(client, input, options \\ []) do
-    request(client, "ListInstanceGroups", input, options)
+  def list_instance_groups(client, input, http_options \\ []) do
+    request(client, "ListInstanceGroups", input, http_options)
   end
 
   @doc """
@@ -132,15 +132,15 @@ defmodule AWS.EMR do
   instances become available to Amazon EMR to use for jobs, and the IP
   addresses for cluster instances, etc.
   """
-  def list_instances(client, input, options \\ []) do
-    request(client, "ListInstances", input, options)
+  def list_instances(client, input, http_options \\ []) do
+    request(client, "ListInstances", input, http_options)
   end
 
   @doc """
   Provides a list of steps for the cluster.
   """
-  def list_steps(client, input, options \\ []) do
-    request(client, "ListSteps", input, options)
+  def list_steps(client, input, http_options \\ []) do
+    request(client, "ListSteps", input, http_options)
   end
 
   @doc """
@@ -149,8 +149,8 @@ defmodule AWS.EMR do
   instance count for the group and the instance group ID. The call will
   either succeed or fail atomically.
   """
-  def modify_instance_groups(client, input, options \\ []) do
-    request(client, "ModifyInstanceGroups", input, options)
+  def modify_instance_groups(client, input, http_options \\ []) do
+    request(client, "ModifyInstanceGroups", input, http_options)
   end
 
   @doc """
@@ -162,8 +162,8 @@ defmodule AWS.EMR do
 
   The following example removes the stack tag with value Prod from a cluster:
   """
-  def remove_tags(client, input, options \\ []) do
-    request(client, "RemoveTags", input, options)
+  def remove_tags(client, input, http_options \\ []) do
+    request(client, "RemoveTags", input, http_options)
   end
 
   @doc """
@@ -194,8 +194,8 @@ defmodule AWS.EMR do
   For long running job flows, we recommend that you periodically store your
   results.
   """
-  def run_job_flow(client, input, options \\ []) do
-    request(client, "RunJobFlow", input, options)
+  def run_job_flow(client, input, http_options \\ []) do
+    request(client, "RunJobFlow", input, http_options)
   end
 
   @doc """
@@ -220,8 +220,8 @@ defmodule AWS.EMR do
   Termination](http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/UsingEMR_TerminationProtection.html)
   in the *Amazon Elastic MapReduce Developer's Guide.*
   """
-  def set_termination_protection(client, input, options \\ []) do
-    request(client, "SetTerminationProtection", input, options)
+  def set_termination_protection(client, input, http_options \\ []) do
+    request(client, "SetTerminationProtection", input, http_options)
   end
 
   @doc """
@@ -232,8 +232,8 @@ defmodule AWS.EMR do
   SetVisibleToAllUsers action can be called only by an IAM user who created
   the job flow or the AWS account that owns the job flow.
   """
-  def set_visible_to_all_users(client, input, options \\ []) do
-    request(client, "SetVisibleToAllUsers", input, options)
+  def set_visible_to_all_users(client, input, http_options \\ []) do
+    request(client, "SetVisibleToAllUsers", input, http_options)
   end
 
   @doc """
@@ -248,11 +248,11 @@ defmodule AWS.EMR do
   take up to 5-20 minutes for the job flow to completely terminate and
   release allocated resources, such as Amazon EC2 instances.
   """
-  def terminate_job_flows(client, input, options \\ []) do
-    request(client, "TerminateJobFlows", input, options)
+  def terminate_job_flows(client, input, http_options \\ []) do
+    request(client, "TerminateJobFlows", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "elasticmapreduce"}
     host = "elasticmapreduce.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -261,12 +261,12 @@ defmodule AWS.EMR do
                {"X-Amz-Target", "ElasticMapReduce.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/glacier.ex
+++ b/lib/aws/glacier.ex
@@ -67,10 +67,10 @@ defmodule AWS.Glacier do
   Upload](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def abort_multipart_upload(client, account_id, upload_id, vault_name, input, options \\ []) do
+  def abort_multipart_upload(client, account_id, upload_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/multipart-uploads/#{URI.encode(upload_id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -94,10 +94,10 @@ defmodule AWS.Glacier do
   multiple times, if the vault lock is in the `InProgress` state or if there
   is no policy associated with the vault.
   """
-  def abort_vault_lock(client, account_id, vault_name, input, options \\ []) do
+  def abort_vault_lock(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/lock-policy"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -109,10 +109,10 @@ defmodule AWS.Glacier do
   information about tags, see [Tagging Amazon Glacier
   Resources](http://docs.aws.amazon.com/amazonglacier/latest/dev/tagging.html).
   """
-  def add_tags_to_vault(client, account_id, vault_name, input, options \\ []) do
+  def add_tags_to_vault(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/tags?operation=add"
     headers = []
-    request(client, :post, url, headers, input, options, 204)
+    request(client, :post, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -165,7 +165,7 @@ defmodule AWS.Glacier do
   Upload](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-complete-upload.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def complete_multipart_upload(client, account_id, upload_id, vault_name, input, options \\ []) do
+  def complete_multipart_upload(client, account_id, upload_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/multipart-uploads/#{URI.encode(upload_id)}"
     headers = []
     if Dict.has_key?(input, "archiveSize") do
@@ -176,7 +176,7 @@ defmodule AWS.Glacier do
       headers = [{"checksum", input["checksum"]}|headers]
       input = Dict.delete(input, "checksum")
     end
-    case request(client, :post, url, headers, input, options, 201) do
+    case request(client, :post, url, headers, input, http_options, 201) do
       {:ok, body, response} ->
         if !is_nil(response.headers["archiveId"]) do
           body = %{body | "archiveId" => response.headers["archiveId"]}
@@ -211,10 +211,10 @@ defmodule AWS.Glacier do
   If an invalid lock ID is passed in the request when the vault lock is in
   the `InProgress` state, the operation throws an `InvalidParameter` error.
   """
-  def complete_vault_lock(client, account_id, lock_id, vault_name, input, options \\ []) do
+  def complete_vault_lock(client, account_id, lock_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/lock-policy/#{URI.encode(lock_id)}"
     headers = []
-    request(client, :post, url, headers, input, options, 204)
+    request(client, :post, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -248,10 +248,10 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-put.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def create_vault(client, account_id, vault_name, input, options \\ []) do
+  def create_vault(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}"
     headers = []
-    case request(client, :put, url, headers, input, options, 201) do
+    case request(client, :put, url, headers, input, http_options, 201) do
       {:ok, body, response} ->
         if !is_nil(response.headers["location"]) do
           body = %{body | "location" => response.headers["location"]}
@@ -290,10 +290,10 @@ defmodule AWS.Glacier do
   Archive](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-delete.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def delete_archive(client, account_id, archive_id, vault_name, input, options \\ []) do
+  def delete_archive(client, account_id, archive_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/archives/#{URI.encode(archive_id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -325,10 +325,10 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-delete.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def delete_vault(client, account_id, vault_name, input, options \\ []) do
+  def delete_vault(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -343,10 +343,10 @@ defmodule AWS.Glacier do
   vault access policies, see [Amazon Glacier Access Control with Vault Access
   Policies](http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-access-policy.html).
   """
-  def delete_vault_access_policy(client, account_id, vault_name, input, options \\ []) do
+  def delete_vault_access_policy(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/access-policy"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -370,10 +370,10 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-delete.html)
   in the Amazon Glacier Developer Guide.
   """
-  def delete_vault_notifications(client, account_id, vault_name, input, options \\ []) do
+  def delete_vault_notifications(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/notification-configuration"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -403,10 +403,10 @@ defmodule AWS.Glacier do
   Glacier](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-describe-job-get.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def describe_job(client, account_id, job_id, vault_name, options \\ []) do
+  def describe_job(client, account_id, job_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/jobs/#{URI.encode(job_id)}"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -436,10 +436,10 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-get.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def describe_vault(client, account_id, vault_name, options \\ []) do
+  def describe_vault(client, account_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -448,10 +448,10 @@ defmodule AWS.Glacier do
   retrieval policies, see [Amazon Glacier Data Retrieval
   Policies](http://docs.aws.amazon.com/amazonglacier/latest/dev/data-retrieval-policy.html).
   """
-  def get_data_retrieval_policy(client, account_id, options \\ []) do
+  def get_data_retrieval_policy(client, account_id, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/policies/data-retrieval"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -505,13 +505,13 @@ defmodule AWS.Glacier do
   and [Get Job Output
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-job-output-get.html)
   """
-  def get_job_output(client, account_id, job_id, vault_name, range \\ nil, options \\ []) do
+  def get_job_output(client, account_id, job_id, vault_name, range \\ nil, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/jobs/#{URI.encode(job_id)}/output"
     headers = []
     if !is_nil(range) do
       headers = [{"range", range}|headers]
     end
-    case request(client, :get, url, headers, nil, options, nil) do
+    case request(client, :get, url, headers, nil, http_options, nil) do
       {:ok, body, response} ->
         if !is_nil(response.headers["acceptRanges"]) do
           body = %{body | "acceptRanges" => response.headers["acceptRanges"]}
@@ -544,10 +544,10 @@ defmodule AWS.Glacier do
   [Amazon Glacier Access Control with Vault Access
   Policies](http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-access-policy.html).
   """
-  def get_vault_access_policy(client, account_id, vault_name, options \\ []) do
+  def get_vault_access_policy(client, account_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/access-policy"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -578,10 +578,10 @@ defmodule AWS.Glacier do
   [Amazon Glacier Access Control with Vault Lock
   Policies](http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-lock-policy.html).
   """
-  def get_vault_lock(client, account_id, vault_name, options \\ []) do
+  def get_vault_lock(client, account_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/lock-policy"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -609,10 +609,10 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-get.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def get_vault_notifications(client, account_id, vault_name, options \\ []) do
+  def get_vault_notifications(client, account_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/notification-configuration"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -744,10 +744,10 @@ defmodule AWS.Glacier do
   and [Downloading a Vault
   Inventory](http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-inventory.html)
   """
-  def initiate_job(client, account_id, vault_name, input, options \\ []) do
+  def initiate_job(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/jobs"
     headers = []
-    case request(client, :post, url, headers, input, options, 202) do
+    case request(client, :post, url, headers, input, http_options, 202) do
       {:ok, body, response} ->
         if !is_nil(response.headers["jobId"]) do
           body = %{body | "jobId" => response.headers["jobId"]}
@@ -802,7 +802,7 @@ defmodule AWS.Glacier do
   Upload](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-initiate-upload.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def initiate_multipart_upload(client, account_id, vault_name, input, options \\ []) do
+  def initiate_multipart_upload(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/multipart-uploads"
     headers = []
     if Dict.has_key?(input, "archiveDescription") do
@@ -813,7 +813,7 @@ defmodule AWS.Glacier do
       headers = [{"partSize", input["partSize"]}|headers]
       input = Dict.delete(input, "partSize")
     end
-    case request(client, :post, url, headers, input, options, 201) do
+    case request(client, :post, url, headers, input, http_options, 201) do
       {:ok, body, response} ->
         if !is_nil(response.headers["location"]) do
           body = %{body | "location" => response.headers["location"]}
@@ -863,10 +863,10 @@ defmodule AWS.Glacier do
   vault lock is in the `InProgress` state you must call `AbortVaultLock`
   before you can initiate a new vault lock policy.
   """
-  def initiate_vault_lock(client, account_id, vault_name, input, options \\ []) do
+  def initiate_vault_lock(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/lock-policy"
     headers = []
-    case request(client, :post, url, headers, input, options, 201) do
+    case request(client, :post, url, headers, input, http_options, 201) do
       {:ok, body, response} ->
         if !is_nil(response.headers["lockId"]) do
           body = %{body | "lockId" => response.headers["lockId"]}
@@ -923,10 +923,10 @@ defmodule AWS.Glacier do
   For the underlying REST API, go to [List Jobs
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-jobs-get.html)
   """
-  def list_jobs(client, account_id, vault_name, options \\ []) do
+  def list_jobs(client, account_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/jobs"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -965,10 +965,10 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-list-uploads.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def list_multipart_uploads(client, account_id, vault_name, options \\ []) do
+  def list_multipart_uploads(client, account_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/multipart-uploads"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -1003,10 +1003,10 @@ defmodule AWS.Glacier do
   Parts](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-list-parts.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def list_parts(client, account_id, upload_id, vault_name, options \\ []) do
+  def list_parts(client, account_id, upload_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/multipart-uploads/#{URI.encode(upload_id)}"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -1015,10 +1015,10 @@ defmodule AWS.Glacier do
   see [Tagging Amazon Glacier
   Resources](http://docs.aws.amazon.com/amazonglacier/latest/dev/tagging.html).
   """
-  def list_tags_for_vault(client, account_id, vault_name, options \\ []) do
+  def list_tags_for_vault(client, account_id, vault_name, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/tags"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -1049,10 +1049,10 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vaults-get.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def list_vaults(client, account_id, options \\ []) do
+  def list_vaults(client, account_id, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -1062,10 +1062,10 @@ defmodule AWS.Glacier do
   This operation is idempotent. The operation will be successful, even if
   there are no tags attached to the vault.
   """
-  def remove_tags_from_vault(client, account_id, vault_name, input, options \\ []) do
+  def remove_tags_from_vault(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/tags?operation=remove"
     headers = []
-    request(client, :post, url, headers, input, options, 204)
+    request(client, :post, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -1079,10 +1079,10 @@ defmodule AWS.Glacier do
   retrieval policies, see [Amazon Glacier Data Retrieval
   Policies](http://docs.aws.amazon.com/amazonglacier/latest/dev/data-retrieval-policy.html).
   """
-  def set_data_retrieval_policy(client, account_id, input, options \\ []) do
+  def set_data_retrieval_policy(client, account_id, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/policies/data-retrieval"
     headers = []
-    request(client, :put, url, headers, input, options, 204)
+    request(client, :put, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -1095,10 +1095,10 @@ defmodule AWS.Glacier do
   with Vault Access
   Policies](http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-access-policy.html).
   """
-  def set_vault_access_policy(client, account_id, vault_name, input, options \\ []) do
+  def set_vault_access_policy(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/access-policy"
     headers = []
-    request(client, :put, url, headers, input, options, 204)
+    request(client, :put, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -1137,10 +1137,10 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-put.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def set_vault_notifications(client, account_id, vault_name, input, options \\ []) do
+  def set_vault_notifications(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/notification-configuration"
     headers = []
-    request(client, :put, url, headers, input, options, 204)
+    request(client, :put, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -1187,7 +1187,7 @@ defmodule AWS.Glacier do
   Archive](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def upload_archive(client, account_id, vault_name, input, options \\ []) do
+  def upload_archive(client, account_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/archives"
     headers = []
     if Dict.has_key?(input, "archiveDescription") do
@@ -1198,7 +1198,7 @@ defmodule AWS.Glacier do
       headers = [{"checksum", input["checksum"]}|headers]
       input = Dict.delete(input, "checksum")
     end
-    case request(client, :post, url, headers, input, options, 201) do
+    case request(client, :post, url, headers, input, http_options, 201) do
       {:ok, body, response} ->
         if !is_nil(response.headers["archiveId"]) do
           body = %{body | "archiveId" => response.headers["archiveId"]}
@@ -1265,7 +1265,7 @@ defmodule AWS.Glacier do
   ](http://docs.aws.amazon.com/amazonglacier/latest/dev/api-upload-part.html)
   in the *Amazon Glacier Developer Guide*.
   """
-  def upload_multipart_part(client, account_id, upload_id, vault_name, input, options \\ []) do
+  def upload_multipart_part(client, account_id, upload_id, vault_name, input, http_options \\ []) do
     url = "/#{URI.encode(account_id)}/vaults/#{URI.encode(vault_name)}/multipart-uploads/#{URI.encode(upload_id)}"
     headers = []
     if Dict.has_key?(input, "checksum") do
@@ -1276,7 +1276,7 @@ defmodule AWS.Glacier do
       headers = [{"range", input["range"]}|headers]
       input = Dict.delete(input, "range")
     end
-    case request(client, :put, url, headers, input, options, 204) do
+    case request(client, :put, url, headers, input, http_options, 204) do
       {:ok, body, response} ->
         if !is_nil(response.headers["checksum"]) do
           body = %{body | "checksum" => response.headers["checksum"]}
@@ -1287,7 +1287,7 @@ defmodule AWS.Glacier do
     end
   end
 
-  defp request(client, method, url, headers, input, options, success_status_code) do
+  defp request(client, method, url, headers, input, http_options, success_status_code) do
     client = %{client | service: "glacier"}
     host = "glacier.#{client.region}.#{client.endpoint}"
     url = "https://#{host}#{url}"
@@ -1296,32 +1296,32 @@ defmodule AWS.Glacier do
                           headers)
     payload = encode_payload(input)
     headers = AWS.Request.sign_v4(client, method, url, headers, payload)
-    perform_request(method, url, payload, headers, options, success_status_code)
+    perform_request(method, url, payload, headers, http_options, success_status_code)
   end
 
-  defp perform_request(method, url, payload, headers, options, nil) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, nil) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 202, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 204, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end
   end
 
-  defp perform_request(method, url, payload, headers, options, success_status_code) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, success_status_code) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/kinesis.ex
+++ b/lib/aws/kinesis.ex
@@ -16,8 +16,8 @@ defmodule AWS.Kinesis do
   If tags have already been assigned to the stream, `AddTagsToStream`
   overwrites any existing tags that correspond to the specified tag keys.
   """
-  def add_tags_to_stream(client, input, options \\ []) do
-    request(client, "AddTagsToStream", input, options)
+  def add_tags_to_stream(client, input, http_options \\ []) do
+    request(client, "AddTagsToStream", input, http_options)
   end
 
   @doc """
@@ -61,8 +61,8 @@ defmodule AWS.Kinesis do
 
   `CreateStream` has a limit of 5 transactions per second per account.
   """
-  def create_stream(client, input, options \\ []) do
-    request(client, "CreateStream", input, options)
+  def create_stream(client, input, http_options \\ []) do
+    request(client, "CreateStream", input, http_options)
   end
 
   @doc """
@@ -87,8 +87,8 @@ defmodule AWS.Kinesis do
 
   `DeleteStream` has a limit of 5 transactions per second per account.
   """
-  def delete_stream(client, input, options \\ []) do
-    request(client, "DeleteStream", input, options)
+  def delete_stream(client, input, http_options \\ []) do
+    request(client, "DeleteStream", input, http_options)
   end
 
   @doc """
@@ -115,8 +115,8 @@ defmodule AWS.Kinesis do
 
   `DescribeStream` has a limit of 10 transactions per second per account.
   """
-  def describe_stream(client, input, options \\ []) do
-    request(client, "DescribeStream", input, options)
+  def describe_stream(client, input, http_options \\ []) do
+    request(client, "DescribeStream", input, http_options)
   end
 
   @doc """
@@ -169,8 +169,8 @@ defmodule AWS.Kinesis do
   CloudWatch](http://docs.aws.amazon.com/kinesis/latest/dev/monitoring_with_cloudwatch.html)
   in the *Amazon Kinesis Developer Guide*.
   """
-  def get_records(client, input, options \\ []) do
-    request(client, "GetRecords", input, options)
+  def get_records(client, input, http_options \\ []) do
+    request(client, "GetRecords", input, http_options)
   end
 
   @doc """
@@ -216,8 +216,8 @@ defmodule AWS.Kinesis do
   `GetShardIterator` has a limit of 5 transactions per second per account per
   open shard.
   """
-  def get_shard_iterator(client, input, options \\ []) do
-    request(client, "GetShardIterator", input, options)
+  def get_shard_iterator(client, input, http_options \\ []) do
+    request(client, "GetShardIterator", input, http_options)
   end
 
   @doc """
@@ -239,15 +239,15 @@ defmodule AWS.Kinesis do
 
   `ListStreams` has a limit of 5 transactions per second per account.
   """
-  def list_streams(client, input, options \\ []) do
-    request(client, "ListStreams", input, options)
+  def list_streams(client, input, http_options \\ []) do
+    request(client, "ListStreams", input, http_options)
   end
 
   @doc """
   Lists the tags for the specified Amazon Kinesis stream.
   """
-  def list_tags_for_stream(client, input, options \\ []) do
-    request(client, "ListTagsForStream", input, options)
+  def list_tags_for_stream(client, input, http_options \\ []) do
+    request(client, "ListTagsForStream", input, http_options)
   end
 
   @doc """
@@ -291,8 +291,8 @@ defmodule AWS.Kinesis do
 
   `MergeShards` has limit of 5 transactions per second per account.
   """
-  def merge_shards(client, input, options \\ []) do
-    request(client, "MergeShards", input, options)
+  def merge_shards(client, input, http_options \\ []) do
+    request(client, "MergeShards", input, http_options)
   end
 
   @doc """
@@ -339,8 +339,8 @@ defmodule AWS.Kinesis do
   Data records are accessible for only 24 hours from the time that they are
   added to an Amazon Kinesis stream.
   """
-  def put_record(client, input, options \\ []) do
-    request(client, "PutRecord", input, options)
+  def put_record(client, input, http_options \\ []) do
+    request(client, "PutRecord", input, http_options)
   end
 
   @doc """
@@ -405,8 +405,8 @@ defmodule AWS.Kinesis do
   Data records are accessible for only 24 hours from the time that they are
   added to an Amazon Kinesis stream.
   """
-  def put_records(client, input, options \\ []) do
-    request(client, "PutRecords", input, options)
+  def put_records(client, input, http_options \\ []) do
+    request(client, "PutRecords", input, http_options)
   end
 
   @doc """
@@ -414,8 +414,8 @@ defmodule AWS.Kinesis do
 
   If you specify a tag that does not exist, it is ignored.
   """
-  def remove_tags_from_stream(client, input, options \\ []) do
-    request(client, "RemoveTagsFromStream", input, options)
+  def remove_tags_from_stream(client, input, http_options \\ []) do
+    request(client, "RemoveTagsFromStream", input, http_options)
   end
 
   @doc """
@@ -469,11 +469,11 @@ defmodule AWS.Kinesis do
 
   `SplitShard` has limit of 5 transactions per second per account.
   """
-  def split_shard(client, input, options \\ []) do
-    request(client, "SplitShard", input, options)
+  def split_shard(client, input, http_options \\ []) do
+    request(client, "SplitShard", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "kinesis"}
     host = "kinesis.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -482,12 +482,12 @@ defmodule AWS.Kinesis do
                {"X-Amz-Target", "Kinesis_20131202.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/kms.ex
+++ b/lib/aws/kms.ex
@@ -87,8 +87,8 @@ defmodule AWS.KMS do
   Note that you cannot create or update an alias that represents a key in
   another account.
   """
-  def create_alias(client, input, options \\ []) do
-    request(client, "CreateAlias", input, options)
+  def create_alias(client, input, http_options \\ []) do
+    request(client, "CreateAlias", input, http_options)
   end
 
   @doc """
@@ -100,8 +100,8 @@ defmodule AWS.KMS do
   evaluated based on IAM policies attached to the user. <ol>
   <li>`ListGrants`</li> <li>`RetireGrant`</li> <li>`RevokeGrant`</li> </ol>
   """
-  def create_grant(client, input, options \\ []) do
-    request(client, "CreateGrant", input, options)
+  def create_grant(client, input, http_options \\ []) do
+    request(client, "CreateGrant", input, http_options)
   end
 
   @doc """
@@ -111,8 +111,8 @@ defmodule AWS.KMS do
   customer data. For more information about data keys, see `GenerateDataKey`
   and `GenerateDataKeyWithoutPlaintext`.
   """
-  def create_key(client, input, options \\ []) do
-    request(client, "CreateKey", input, options)
+  def create_key(client, input, http_options \\ []) do
+    request(client, "CreateKey", input, http_options)
   end
 
   @doc """
@@ -130,52 +130,52 @@ defmodule AWS.KMS do
   `Decrypt` access in an IAM user policy, you should scope the resource to
   specific keys or to specific trusted accounts.
   """
-  def decrypt(client, input, options \\ []) do
-    request(client, "Decrypt", input, options)
+  def decrypt(client, input, http_options \\ []) do
+    request(client, "Decrypt", input, http_options)
   end
 
   @doc """
   Deletes the specified alias. To associate an alias with a different key,
   call `UpdateAlias`.
   """
-  def delete_alias(client, input, options \\ []) do
-    request(client, "DeleteAlias", input, options)
+  def delete_alias(client, input, http_options \\ []) do
+    request(client, "DeleteAlias", input, http_options)
   end
 
   @doc """
   Provides detailed information about the specified customer master key.
   """
-  def describe_key(client, input, options \\ []) do
-    request(client, "DescribeKey", input, options)
+  def describe_key(client, input, http_options \\ []) do
+    request(client, "DescribeKey", input, http_options)
   end
 
   @doc """
   Marks a key as disabled, thereby preventing its use.
   """
-  def disable_key(client, input, options \\ []) do
-    request(client, "DisableKey", input, options)
+  def disable_key(client, input, http_options \\ []) do
+    request(client, "DisableKey", input, http_options)
   end
 
   @doc """
   Disables rotation of the specified key.
   """
-  def disable_key_rotation(client, input, options \\ []) do
-    request(client, "DisableKeyRotation", input, options)
+  def disable_key_rotation(client, input, http_options \\ []) do
+    request(client, "DisableKeyRotation", input, http_options)
   end
 
   @doc """
   Marks a key as enabled, thereby permitting its use. You can have up to 25
   enabled keys at one time.
   """
-  def enable_key(client, input, options \\ []) do
-    request(client, "EnableKey", input, options)
+  def enable_key(client, input, http_options \\ []) do
+    request(client, "EnableKey", input, http_options)
   end
 
   @doc """
   Enables rotation of the specified customer master key.
   """
-  def enable_key_rotation(client, input, options \\ []) do
-    request(client, "EnableKeyRotation", input, options)
+  def enable_key_rotation(client, input, http_options \\ []) do
+    request(client, "EnableKeyRotation", input, http_options)
   end
 
   @doc """
@@ -200,8 +200,8 @@ defmodule AWS.KMS do
   copy of the key encrypted under the customer master key (CMK) of your
   choosing.
   """
-  def encrypt(client, input, options \\ []) do
-    request(client, "Encrypt", input, options)
+  def encrypt(client, input, http_options \\ []) do
+    request(client, "Encrypt", input, http_options)
   end
 
   @doc """
@@ -238,8 +238,8 @@ defmodule AWS.KMS do
   The encryption context is logged by CloudTrail, and you can use this log to
   help track the use of particular data.
   """
-  def generate_data_key(client, input, options \\ []) do
-    request(client, "GenerateDataKey", input, options)
+  def generate_data_key(client, input, http_options \\ []) do
+    request(client, "GenerateDataKey", input, http_options)
   end
 
   @doc """
@@ -249,65 +249,65 @@ defmodule AWS.KMS do
   requirement that an encrypted key be made available without exposing the
   plaintext copy of that key.
   """
-  def generate_data_key_without_plaintext(client, input, options \\ []) do
-    request(client, "GenerateDataKeyWithoutPlaintext", input, options)
+  def generate_data_key_without_plaintext(client, input, http_options \\ []) do
+    request(client, "GenerateDataKeyWithoutPlaintext", input, http_options)
   end
 
   @doc """
   Generates an unpredictable byte string.
   """
-  def generate_random(client, input, options \\ []) do
-    request(client, "GenerateRandom", input, options)
+  def generate_random(client, input, http_options \\ []) do
+    request(client, "GenerateRandom", input, http_options)
   end
 
   @doc """
   Retrieves a policy attached to the specified key.
   """
-  def get_key_policy(client, input, options \\ []) do
-    request(client, "GetKeyPolicy", input, options)
+  def get_key_policy(client, input, http_options \\ []) do
+    request(client, "GetKeyPolicy", input, http_options)
   end
 
   @doc """
   Retrieves a Boolean value that indicates whether key rotation is enabled
   for the specified key.
   """
-  def get_key_rotation_status(client, input, options \\ []) do
-    request(client, "GetKeyRotationStatus", input, options)
+  def get_key_rotation_status(client, input, http_options \\ []) do
+    request(client, "GetKeyRotationStatus", input, http_options)
   end
 
   @doc """
   Lists all of the key aliases in the account.
   """
-  def list_aliases(client, input, options \\ []) do
-    request(client, "ListAliases", input, options)
+  def list_aliases(client, input, http_options \\ []) do
+    request(client, "ListAliases", input, http_options)
   end
 
   @doc """
   List the grants for a specified key.
   """
-  def list_grants(client, input, options \\ []) do
-    request(client, "ListGrants", input, options)
+  def list_grants(client, input, http_options \\ []) do
+    request(client, "ListGrants", input, http_options)
   end
 
   @doc """
   Retrieves a list of policies attached to a key.
   """
-  def list_key_policies(client, input, options \\ []) do
-    request(client, "ListKeyPolicies", input, options)
+  def list_key_policies(client, input, http_options \\ []) do
+    request(client, "ListKeyPolicies", input, http_options)
   end
 
   @doc """
   Lists the customer master keys.
   """
-  def list_keys(client, input, options \\ []) do
-    request(client, "ListKeys", input, options)
+  def list_keys(client, input, http_options \\ []) do
+    request(client, "ListKeys", input, http_options)
   end
 
   @doc """
   Attaches a policy to the specified key.
   """
-  def put_key_policy(client, input, options \\ []) do
-    request(client, "PutKeyPolicy", input, options)
+  def put_key_policy(client, input, http_options \\ []) do
+    request(client, "PutKeyPolicy", input, http_options)
   end
 
   @doc """
@@ -324,8 +324,8 @@ defmodule AWS.KMS do
   when you authorize use of the key through the console but must be included
   manually when you set a policy by using the `PutKeyPolicy` function.
   """
-  def re_encrypt(client, input, options \\ []) do
-    request(client, "ReEncrypt", input, options)
+  def re_encrypt(client, input, http_options \\ []) do
+    request(client, "ReEncrypt", input, http_options)
   end
 
   @doc """
@@ -340,16 +340,16 @@ defmodule AWS.KMS do
   character unique identifier of a grant. Both are returned by the
   `CreateGrant` function.
   """
-  def retire_grant(client, input, options \\ []) do
-    request(client, "RetireGrant", input, options)
+  def retire_grant(client, input, http_options \\ []) do
+    request(client, "RetireGrant", input, http_options)
   end
 
   @doc """
   Revokes a grant. You can revoke a grant to actively deny operations that
   depend on it.
   """
-  def revoke_grant(client, input, options \\ []) do
-    request(client, "RevokeGrant", input, options)
+  def revoke_grant(client, input, http_options \\ []) do
+    request(client, "RevokeGrant", input, http_options)
   end
 
   @doc """
@@ -368,18 +368,18 @@ defmodule AWS.KMS do
   Note that you cannot create or update an alias that represents a key in
   another account.
   """
-  def update_alias(client, input, options \\ []) do
-    request(client, "UpdateAlias", input, options)
+  def update_alias(client, input, http_options \\ []) do
+    request(client, "UpdateAlias", input, http_options)
   end
 
   @doc """
   Updates the description of a key.
   """
-  def update_key_description(client, input, options \\ []) do
-    request(client, "UpdateKeyDescription", input, options)
+  def update_key_description(client, input, http_options \\ []) do
+    request(client, "UpdateKeyDescription", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "kms"}
     host = "kms.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -388,12 +388,12 @@ defmodule AWS.KMS do
                {"X-Amz-Target", "TrentService.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/lambda.ex
+++ b/lib/aws/lambda.ex
@@ -28,10 +28,10 @@ defmodule AWS.Lambda do
 
   This operation requires permission for the `lambda:AddPermission` action.
   """
-  def add_permission(client, function_name, input, options \\ []) do
+  def add_permission(client, function_name, input, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}/versions/HEAD/policy"
     headers = []
-    request(client, :post, url, headers, input, options, 201)
+    request(client, :post, url, headers, input, http_options, 201)
   end
 
   @doc """
@@ -56,10 +56,10 @@ defmodule AWS.Lambda do
   This operation requires permission for the
   `lambda:CreateEventSourceMapping` action.
   """
-  def create_event_source_mapping(client, input, options \\ []) do
+  def create_event_source_mapping(client, input, http_options \\ []) do
     url = "/2015-03-31/event-source-mappings/"
     headers = []
-    request(client, :post, url, headers, input, options, 202)
+    request(client, :post, url, headers, input, http_options, 202)
   end
 
   @doc """
@@ -70,10 +70,10 @@ defmodule AWS.Lambda do
 
   This operation requires permission for the `lambda:CreateFunction` action.
   """
-  def create_function(client, input, options \\ []) do
+  def create_function(client, input, http_options \\ []) do
     url = "/2015-03-31/functions"
     headers = []
-    request(client, :post, url, headers, input, options, 201)
+    request(client, :post, url, headers, input, http_options, 201)
   end
 
   @doc """
@@ -83,10 +83,10 @@ defmodule AWS.Lambda do
   This operation requires permission for the
   `lambda:DeleteEventSourceMapping` action.
   """
-  def delete_event_source_mapping(client, uuid, input, options \\ []) do
+  def delete_event_source_mapping(client, uuid, input, http_options \\ []) do
     url = "/2015-03-31/event-source-mappings/#{URI.encode(uuid)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 202)
+    request(client, :delete, url, headers, input, http_options, 202)
   end
 
   @doc """
@@ -97,10 +97,10 @@ defmodule AWS.Lambda do
 
   This operation requires permission for the `lambda:DeleteFunction` action.
   """
-  def delete_function(client, function_name, input, options \\ []) do
+  def delete_function(client, function_name, input, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -110,10 +110,10 @@ defmodule AWS.Lambda do
   This operation requires permission for the `lambda:GetEventSourceMapping`
   action.
   """
-  def get_event_source_mapping(client, uuid, options \\ []) do
+  def get_event_source_mapping(client, uuid, http_options \\ []) do
     url = "/2015-03-31/event-source-mappings/#{URI.encode(uuid)}"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -125,10 +125,10 @@ defmodule AWS.Lambda do
 
   This operation requires permission for the `lambda:GetFunction` action.
   """
-  def get_function(client, function_name, options \\ []) do
+  def get_function(client, function_name, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}/versions/HEAD"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -139,10 +139,10 @@ defmodule AWS.Lambda do
   This operation requires permission for the
   `lambda:GetFunctionConfiguration` operation.
   """
-  def get_function_configuration(client, function_name, options \\ []) do
+  def get_function_configuration(client, function_name, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}/versions/HEAD/configuration"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -151,10 +151,10 @@ defmodule AWS.Lambda do
 
   You need permission for the `lambda:GetPolicy action.`
   """
-  def get_policy(client, function_name, options \\ []) do
+  def get_policy(client, function_name, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}/versions/HEAD/policy"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -162,7 +162,7 @@ defmodule AWS.Lambda do
 
   This operation requires permission for the `lambda:InvokeFunction` action.
   """
-  def invoke(client, function_name, input, options \\ []) do
+  def invoke(client, function_name, input, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}/invocations"
     headers = []
     if Dict.has_key?(input, "ClientContext") do
@@ -177,7 +177,7 @@ defmodule AWS.Lambda do
       headers = [{"LogType", input["LogType"]}|headers]
       input = Dict.delete(input, "LogType")
     end
-    case request(client, :post, url, headers, input, options, nil) do
+    case request(client, :post, url, headers, input, http_options, nil) do
       {:ok, body, response} ->
         if !is_nil(response.headers["FunctionError"]) do
           body = %{body | "FunctionError" => response.headers["FunctionError"]}
@@ -200,10 +200,10 @@ defmodule AWS.Lambda do
 
   This operation requires permission for the `lambda:InvokeFunction` action.
   """
-  def invoke_async(client, function_name, input, options \\ []) do
+  def invoke_async(client, function_name, input, http_options \\ []) do
     url = "/2014-11-13/functions/#{URI.encode(function_name)}/invoke-async/"
     headers = []
-    request(client, :post, url, headers, input, options, 202)
+    request(client, :post, url, headers, input, http_options, 202)
   end
 
   @doc """
@@ -218,10 +218,10 @@ defmodule AWS.Lambda do
   This operation requires permission for the `lambda:ListEventSourceMappings`
   action.
   """
-  def list_event_source_mappings(client, options \\ []) do
+  def list_event_source_mappings(client, http_options \\ []) do
     url = "/2015-03-31/event-source-mappings/"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -231,10 +231,10 @@ defmodule AWS.Lambda do
 
   This operation requires permission for the `lambda:ListFunctions` action.
   """
-  def list_functions(client, options \\ []) do
+  def list_functions(client, http_options \\ []) do
     url = "/2015-03-31/functions/"
     headers = []
-    request(client, :get, url, headers, nil, options, 200)
+    request(client, :get, url, headers, nil, http_options, 200)
   end
 
   @doc """
@@ -246,10 +246,10 @@ defmodule AWS.Lambda do
 
   You need permission for the `lambda:RemovePermission` action.
   """
-  def remove_permission(client, function_name, statement_id, input, options \\ []) do
+  def remove_permission(client, function_name, statement_id, input, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}/versions/HEAD/policy/#{URI.encode(statement_id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 204)
+    request(client, :delete, url, headers, input, http_options, 204)
   end
 
   @doc """
@@ -261,10 +261,10 @@ defmodule AWS.Lambda do
   This operation requires permission for the
   `lambda:UpdateEventSourceMapping` action.
   """
-  def update_event_source_mapping(client, uuid, input, options \\ []) do
+  def update_event_source_mapping(client, uuid, input, http_options \\ []) do
     url = "/2015-03-31/event-source-mappings/#{URI.encode(uuid)}"
     headers = []
-    request(client, :put, url, headers, input, options, 202)
+    request(client, :put, url, headers, input, http_options, 202)
   end
 
   @doc """
@@ -275,10 +275,10 @@ defmodule AWS.Lambda do
   This operation requires permission for the `lambda:UpdateFunctionCode`
   action.
   """
-  def update_function_code(client, function_name, input, options \\ []) do
+  def update_function_code(client, function_name, input, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}/versions/HEAD/code"
     headers = []
-    request(client, :put, url, headers, input, options, 200)
+    request(client, :put, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -290,13 +290,13 @@ defmodule AWS.Lambda do
   This operation requires permission for the
   `lambda:UpdateFunctionConfiguration` action.
   """
-  def update_function_configuration(client, function_name, input, options \\ []) do
+  def update_function_configuration(client, function_name, input, http_options \\ []) do
     url = "/2015-03-31/functions/#{URI.encode(function_name)}/versions/HEAD/configuration"
     headers = []
-    request(client, :put, url, headers, input, options, 200)
+    request(client, :put, url, headers, input, http_options, 200)
   end
 
-  defp request(client, method, url, headers, input, options, success_status_code) do
+  defp request(client, method, url, headers, input, http_options, success_status_code) do
     client = %{client | service: "lambda"}
     host = "lambda.#{client.region}.#{client.endpoint}"
     url = "https://#{host}#{url}"
@@ -305,32 +305,32 @@ defmodule AWS.Lambda do
                           headers)
     payload = encode_payload(input)
     headers = AWS.Request.sign_v4(client, method, url, headers, payload)
-    perform_request(method, url, payload, headers, options, success_status_code)
+    perform_request(method, url, payload, headers, http_options, success_status_code)
   end
 
-  defp perform_request(method, url, payload, headers, options, nil) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, nil) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 202, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 204, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end
   end
 
-  defp perform_request(method, url, payload, headers, options, success_status_code) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, success_status_code) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/logs.ex
+++ b/lib/aws/logs.ex
@@ -61,8 +61,8 @@ defmodule AWS.Logs do
   characters are a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), '/' (forward
   slash), and '.' (period).</li> </ul>
   """
-  def create_log_group(client, input, options \\ []) do
-    request(client, "CreateLogGroup", input, options)
+  def create_log_group(client, input, http_options \\ []) do
+    request(client, "CreateLogGroup", input, http_options)
   end
 
   @doc """
@@ -74,8 +74,8 @@ defmodule AWS.Logs do
   <li>Log stream names can be between 1 and 512 characters long.</li> <li>The
   ':' colon character is not allowed.</li> </ul>
   """
-  def create_log_stream(client, input, options \\ []) do
-    request(client, "CreateLogStream", input, options)
+  def create_log_stream(client, input, http_options \\ []) do
+    request(client, "CreateLogStream", input, http_options)
   end
 
   @doc """
@@ -83,46 +83,46 @@ defmodule AWS.Logs do
   the subscription filters that publish to it. This will not delete the
   physical resource encapsulated by the destination.
   """
-  def delete_destination(client, input, options \\ []) do
-    request(client, "DeleteDestination", input, options)
+  def delete_destination(client, input, http_options \\ []) do
+    request(client, "DeleteDestination", input, http_options)
   end
 
   @doc """
   Deletes the log group with the specified name and permanently deletes all
   the archived log events associated with it.
   """
-  def delete_log_group(client, input, options \\ []) do
-    request(client, "DeleteLogGroup", input, options)
+  def delete_log_group(client, input, http_options \\ []) do
+    request(client, "DeleteLogGroup", input, http_options)
   end
 
   @doc """
   Deletes a log stream and permanently deletes all the archived log events
   associated with it.
   """
-  def delete_log_stream(client, input, options \\ []) do
-    request(client, "DeleteLogStream", input, options)
+  def delete_log_stream(client, input, http_options \\ []) do
+    request(client, "DeleteLogStream", input, http_options)
   end
 
   @doc """
   Deletes a metric filter associated with the specified log group.
   """
-  def delete_metric_filter(client, input, options \\ []) do
-    request(client, "DeleteMetricFilter", input, options)
+  def delete_metric_filter(client, input, http_options \\ []) do
+    request(client, "DeleteMetricFilter", input, http_options)
   end
 
   @doc """
   Deletes the retention policy of the specified log group. Log events would
   not expire if they belong to log groups without a retention policy.
   """
-  def delete_retention_policy(client, input, options \\ []) do
-    request(client, "DeleteRetentionPolicy", input, options)
+  def delete_retention_policy(client, input, http_options \\ []) do
+    request(client, "DeleteRetentionPolicy", input, http_options)
   end
 
   @doc """
   Deletes a subscription filter associated with the specified log group.
   """
-  def delete_subscription_filter(client, input, options \\ []) do
-    request(client, "DeleteSubscriptionFilter", input, options)
+  def delete_subscription_filter(client, input, http_options \\ []) do
+    request(client, "DeleteSubscriptionFilter", input, http_options)
   end
 
   @doc """
@@ -136,8 +136,8 @@ defmodule AWS.Logs do
   number of destinations returned in the response by specifying the <code
   class="code">limit` parameter in the request.
   """
-  def describe_destinations(client, input, options \\ []) do
-    request(client, "DescribeDestinations", input, options)
+  def describe_destinations(client, input, http_options \\ []) do
+    request(client, "DescribeDestinations", input, http_options)
   end
 
   @doc """
@@ -151,8 +151,8 @@ defmodule AWS.Logs do
   number of log groups returned in the response by specifying the <code
   class="code">limit` parameter in the request.
   """
-  def describe_log_groups(client, input, options \\ []) do
-    request(client, "DescribeLogGroups", input, options)
+  def describe_log_groups(client, input, http_options \\ []) do
+    request(client, "DescribeLogGroups", input, http_options)
   end
 
   @doc """
@@ -167,8 +167,8 @@ defmodule AWS.Logs do
   class="code">limit` parameter in the request. This operation has a limit of
   five transactions per second, after which transactions are throttled.
   """
-  def describe_log_streams(client, input, options \\ []) do
-    request(client, "DescribeLogStreams", input, options)
+  def describe_log_streams(client, input, http_options \\ []) do
+    request(client, "DescribeLogStreams", input, http_options)
   end
 
   @doc """
@@ -181,8 +181,8 @@ defmodule AWS.Logs do
   number of metric filters returned in the response by specifying the <code
   class="code">limit` parameter in the request.
   """
-  def describe_metric_filters(client, input, options \\ []) do
-    request(client, "DescribeMetricFilters", input, options)
+  def describe_metric_filters(client, input, http_options \\ []) do
+    request(client, "DescribeMetricFilters", input, http_options)
   end
 
   @doc """
@@ -195,8 +195,8 @@ defmodule AWS.Logs do
   number of subscription filters returned in the response by specifying the
   <code class="code">limit` parameter in the request.
   """
-  def describe_subscription_filters(client, input, options \\ []) do
-    request(client, "DescribeSubscriptionFilters", input, options)
+  def describe_subscription_filters(client, input, http_options \\ []) do
+    request(client, "DescribeSubscriptionFilters", input, http_options)
   end
 
   @doc """
@@ -216,8 +216,8 @@ defmodule AWS.Logs do
   class="code">limit` parameter in the request. can be used to specify the
   maximum number of events to return in a page.
   """
-  def filter_log_events(client, input, options \\ []) do
-    request(client, "FilterLogEvents", input, options)
+  def filter_log_events(client, input, http_options \\ []) do
+    request(client, "FilterLogEvents", input, http_options)
   end
 
   @doc """
@@ -234,8 +234,8 @@ defmodule AWS.Logs do
   also limit the number of log events returned in the response by specifying
   the <code class="code">limit` parameter in the request.
   """
-  def get_log_events(client, input, options \\ []) do
-    request(client, "GetLogEvents", input, options)
+  def get_log_events(client, input, http_options \\ []) do
+    request(client, "GetLogEvents", input, http_options)
   end
 
   @doc """
@@ -252,8 +252,8 @@ defmodule AWS.Logs do
   call `PutSubscriptionFilter` against this destination. To enable that, the
   destination owner must call `PutDestinationPolicy` after PutDestination.
   """
-  def put_destination(client, input, options \\ []) do
-    request(client, "PutDestination", input, options)
+  def put_destination(client, input, http_options \\ []) do
+    request(client, "PutDestination", input, http_options)
   end
 
   @doc """
@@ -263,8 +263,8 @@ defmodule AWS.Logs do
   that is used to authorize claims to register a subscription filter against
   a given destination.
   """
-  def put_destination_policy(client, input, options \\ []) do
-    request(client, "PutDestinationPolicy", input, options)
+  def put_destination_policy(client, input, http_options \\ []) do
+    request(client, "PutDestinationPolicy", input, http_options)
   end
 
   @doc """
@@ -285,8 +285,8 @@ defmodule AWS.Logs do
   class="code">timestamp`.</li> <li>The maximum number of log events in a
   batch is 10,000.</li> </ul>
   """
-  def put_log_events(client, input, options \\ []) do
-    request(client, "PutLogEvents", input, options)
+  def put_log_events(client, input, http_options \\ []) do
+    request(client, "PutLogEvents", input, http_options)
   end
 
   @doc """
@@ -297,8 +297,8 @@ defmodule AWS.Logs do
   The maximum number of metric filters that can be associated with a log
   group is 100.
   """
-  def put_metric_filter(client, input, options \\ []) do
-    request(client, "PutMetricFilter", input, options)
+  def put_metric_filter(client, input, http_options \\ []) do
+    request(client, "PutMetricFilter", input, http_options)
   end
 
   @doc """
@@ -306,8 +306,8 @@ defmodule AWS.Logs do
   you to configure the number of days you want to retain log events in the
   specified log group.
   """
-  def put_retention_policy(client, input, options \\ []) do
-    request(client, "PutRetentionPolicy", input, options)
+  def put_retention_policy(client, input, http_options \\ []) do
+    request(client, "PutRetentionPolicy", input, http_options)
   end
 
   @doc """
@@ -324,8 +324,8 @@ defmodule AWS.Logs do
   Currently there can only be one subscription filter associated with a log
   group.
   """
-  def put_subscription_filter(client, input, options \\ []) do
-    request(client, "PutSubscriptionFilter", input, options)
+  def put_subscription_filter(client, input, http_options \\ []) do
+    request(client, "PutSubscriptionFilter", input, http_options)
   end
 
   @doc """
@@ -333,11 +333,11 @@ defmodule AWS.Logs do
   messages. You can use this operation to validate the correctness of a
   metric filter pattern.
   """
-  def test_metric_filter(client, input, options \\ []) do
-    request(client, "TestMetricFilter", input, options)
+  def test_metric_filter(client, input, http_options \\ []) do
+    request(client, "TestMetricFilter", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "logs"}
     host = "logs.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -346,12 +346,12 @@ defmodule AWS.Logs do
                {"X-Amz-Target", "Logs_20140328.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/ops_works.ex
+++ b/lib/aws/ops_works.ex
@@ -68,8 +68,8 @@ defmodule AWS.OpsWorks do
   User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def assign_instance(client, input, options \\ []) do
-    request(client, "AssignInstance", input, options)
+  def assign_instance(client, input, http_options \\ []) do
+    request(client, "AssignInstance", input, http_options)
   end
 
   @doc """
@@ -86,8 +86,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def assign_volume(client, input, options \\ []) do
-    request(client, "AssignVolume", input, options)
+  def assign_volume(client, input, http_options \\ []) do
+    request(client, "AssignVolume", input, http_options)
   end
 
   @doc """
@@ -102,8 +102,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def associate_elastic_ip(client, input, options \\ []) do
-    request(client, "AssociateElasticIp", input, options)
+  def associate_elastic_ip(client, input, http_options \\ []) do
+    request(client, "AssociateElasticIp", input, http_options)
   end
 
   @doc """
@@ -122,8 +122,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def attach_elastic_load_balancer(client, input, options \\ []) do
-    request(client, "AttachElasticLoadBalancer", input, options)
+  def attach_elastic_load_balancer(client, input, http_options \\ []) do
+    request(client, "AttachElasticLoadBalancer", input, http_options)
   end
 
   @doc """
@@ -136,8 +136,8 @@ defmodule AWS.OpsWorks do
   user permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def clone_stack(client, input, options \\ []) do
-    request(client, "CloneStack", input, options)
+  def clone_stack(client, input, http_options \\ []) do
+    request(client, "CloneStack", input, http_options)
   end
 
   @doc """
@@ -150,8 +150,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def create_app(client, input, options \\ []) do
-    request(client, "CreateApp", input, options)
+  def create_app(client, input, http_options \\ []) do
+    request(client, "CreateApp", input, http_options)
   end
 
   @doc """
@@ -166,8 +166,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def create_deployment(client, input, options \\ []) do
-    request(client, "CreateDeployment", input, options)
+  def create_deployment(client, input, http_options \\ []) do
+    request(client, "CreateDeployment", input, http_options)
   end
 
   @doc """
@@ -181,8 +181,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def create_instance(client, input, options \\ []) do
-    request(client, "CreateInstance", input, options)
+  def create_instance(client, input, http_options \\ []) do
+    request(client, "CreateInstance", input, http_options)
   end
 
   @doc """
@@ -202,8 +202,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def create_layer(client, input, options \\ []) do
-    request(client, "CreateLayer", input, options)
+  def create_layer(client, input, http_options \\ []) do
+    request(client, "CreateLayer", input, http_options)
   end
 
   @doc """
@@ -215,8 +215,8 @@ defmodule AWS.OpsWorks do
   user permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def create_stack(client, input, options \\ []) do
-    request(client, "CreateStack", input, options)
+  def create_stack(client, input, http_options \\ []) do
+    request(client, "CreateStack", input, http_options)
   end
 
   @doc """
@@ -227,8 +227,8 @@ defmodule AWS.OpsWorks do
   user permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def create_user_profile(client, input, options \\ []) do
-    request(client, "CreateUserProfile", input, options)
+  def create_user_profile(client, input, http_options \\ []) do
+    request(client, "CreateUserProfile", input, http_options)
   end
 
   @doc """
@@ -240,8 +240,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def delete_app(client, input, options \\ []) do
-    request(client, "DeleteApp", input, options)
+  def delete_app(client, input, http_options \\ []) do
+    request(client, "DeleteApp", input, http_options)
   end
 
   @doc """
@@ -257,8 +257,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def delete_instance(client, input, options \\ []) do
-    request(client, "DeleteInstance", input, options)
+  def delete_instance(client, input, http_options \\ []) do
+    request(client, "DeleteInstance", input, http_options)
   end
 
   @doc """
@@ -273,8 +273,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def delete_layer(client, input, options \\ []) do
-    request(client, "DeleteLayer", input, options)
+  def delete_layer(client, input, http_options \\ []) do
+    request(client, "DeleteLayer", input, http_options)
   end
 
   @doc """
@@ -289,8 +289,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def delete_stack(client, input, options \\ []) do
-    request(client, "DeleteStack", input, options)
+  def delete_stack(client, input, http_options \\ []) do
+    request(client, "DeleteStack", input, http_options)
   end
 
   @doc """
@@ -301,8 +301,8 @@ defmodule AWS.OpsWorks do
   user permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def delete_user_profile(client, input, options \\ []) do
-    request(client, "DeleteUserProfile", input, options)
+  def delete_user_profile(client, input, http_options \\ []) do
+    request(client, "DeleteUserProfile", input, http_options)
   end
 
   @doc """
@@ -316,8 +316,8 @@ defmodule AWS.OpsWorks do
   see <a
   href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">`.
   """
-  def deregister_ecs_cluster(client, input, options \\ []) do
-    request(client, "DeregisterEcsCluster", input, options)
+  def deregister_ecs_cluster(client, input, http_options \\ []) do
+    request(client, "DeregisterEcsCluster", input, http_options)
   end
 
   @doc """
@@ -331,8 +331,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def deregister_elastic_ip(client, input, options \\ []) do
-    request(client, "DeregisterElasticIp", input, options)
+  def deregister_elastic_ip(client, input, http_options \\ []) do
+    request(client, "DeregisterElasticIp", input, http_options)
   end
 
   @doc """
@@ -346,8 +346,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def deregister_instance(client, input, options \\ []) do
-    request(client, "DeregisterInstance", input, options)
+  def deregister_instance(client, input, http_options \\ []) do
+    request(client, "DeregisterInstance", input, http_options)
   end
 
   @doc """
@@ -359,8 +359,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def deregister_rds_db_instance(client, input, options \\ []) do
-    request(client, "DeregisterRdsDbInstance", input, options)
+  def deregister_rds_db_instance(client, input, http_options \\ []) do
+    request(client, "DeregisterRdsDbInstance", input, http_options)
   end
 
   @doc """
@@ -374,8 +374,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def deregister_volume(client, input, options \\ []) do
-    request(client, "DeregisterVolume", input, options)
+  def deregister_volume(client, input, http_options \\ []) do
+    request(client, "DeregisterVolume", input, http_options)
   end
 
   @doc """
@@ -384,8 +384,8 @@ defmodule AWS.OpsWorks do
   of available agent versions for the specified stack or configuration
   manager.
   """
-  def describe_agent_versions(client, input, options \\ []) do
-    request(client, "DescribeAgentVersions", input, options)
+  def describe_agent_versions(client, input, http_options \\ []) do
+    request(client, "DescribeAgentVersions", input, http_options)
   end
 
   @doc """
@@ -399,8 +399,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_apps(client, input, options \\ []) do
-    request(client, "DescribeApps", input, options)
+  def describe_apps(client, input, http_options \\ []) do
+    request(client, "DescribeApps", input, http_options)
   end
 
   @doc """
@@ -414,8 +414,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_commands(client, input, options \\ []) do
-    request(client, "DescribeCommands", input, options)
+  def describe_commands(client, input, http_options \\ []) do
+    request(client, "DescribeCommands", input, http_options)
   end
 
   @doc """
@@ -429,8 +429,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_deployments(client, input, options \\ []) do
-    request(client, "DescribeDeployments", input, options)
+  def describe_deployments(client, input, http_options \\ []) do
+    request(client, "DescribeDeployments", input, http_options)
   end
 
   @doc """
@@ -446,8 +446,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_ecs_clusters(client, input, options \\ []) do
-    request(client, "DescribeEcsClusters", input, options)
+  def describe_ecs_clusters(client, input, http_options \\ []) do
+    request(client, "DescribeEcsClusters", input, http_options)
   end
 
   @doc """
@@ -462,8 +462,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_elastic_ips(client, input, options \\ []) do
-    request(client, "DescribeElasticIps", input, options)
+  def describe_elastic_ips(client, input, http_options \\ []) do
+    request(client, "DescribeElasticIps", input, http_options)
   end
 
   @doc """
@@ -477,8 +477,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_elastic_load_balancers(client, input, options \\ []) do
-    request(client, "DescribeElasticLoadBalancers", input, options)
+  def describe_elastic_load_balancers(client, input, http_options \\ []) do
+    request(client, "DescribeElasticLoadBalancers", input, http_options)
   end
 
   @doc """
@@ -492,8 +492,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_instances(client, input, options \\ []) do
-    request(client, "DescribeInstances", input, options)
+  def describe_instances(client, input, http_options \\ []) do
+    request(client, "DescribeInstances", input, http_options)
   end
 
   @doc """
@@ -507,8 +507,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_layers(client, input, options \\ []) do
-    request(client, "DescribeLayers", input, options)
+  def describe_layers(client, input, http_options \\ []) do
+    request(client, "DescribeLayers", input, http_options)
   end
 
   @doc """
@@ -522,8 +522,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_load_based_auto_scaling(client, input, options \\ []) do
-    request(client, "DescribeLoadBasedAutoScaling", input, options)
+  def describe_load_based_auto_scaling(client, input, http_options \\ []) do
+    request(client, "DescribeLoadBasedAutoScaling", input, http_options)
   end
 
   @doc """
@@ -534,8 +534,8 @@ defmodule AWS.OpsWorks do
   permissions. For more information on user permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_my_user_profile(client, input, options \\ []) do
-    request(client, "DescribeMyUserProfile", input, options)
+  def describe_my_user_profile(client, input, http_options \\ []) do
+    request(client, "DescribeMyUserProfile", input, http_options)
   end
 
   @doc """
@@ -547,8 +547,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_permissions(client, input, options \\ []) do
-    request(client, "DescribePermissions", input, options)
+  def describe_permissions(client, input, http_options \\ []) do
+    request(client, "DescribePermissions", input, http_options)
   end
 
   @doc """
@@ -562,8 +562,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_raid_arrays(client, input, options \\ []) do
-    request(client, "DescribeRaidArrays", input, options)
+  def describe_raid_arrays(client, input, http_options \\ []) do
+    request(client, "DescribeRaidArrays", input, http_options)
   end
 
   @doc """
@@ -575,8 +575,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_rds_db_instances(client, input, options \\ []) do
-    request(client, "DescribeRdsDbInstances", input, options)
+  def describe_rds_db_instances(client, input, http_options \\ []) do
+    request(client, "DescribeRdsDbInstances", input, http_options)
   end
 
   @doc """
@@ -588,8 +588,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_service_errors(client, input, options \\ []) do
-    request(client, "DescribeServiceErrors", input, options)
+  def describe_service_errors(client, input, http_options \\ []) do
+    request(client, "DescribeServiceErrors", input, http_options)
   end
 
   @doc """
@@ -601,8 +601,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_stack_provisioning_parameters(client, input, options \\ []) do
-    request(client, "DescribeStackProvisioningParameters", input, options)
+  def describe_stack_provisioning_parameters(client, input, http_options \\ []) do
+    request(client, "DescribeStackProvisioningParameters", input, http_options)
   end
 
   @doc """
@@ -615,8 +615,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_stack_summary(client, input, options \\ []) do
-    request(client, "DescribeStackSummary", input, options)
+  def describe_stack_summary(client, input, http_options \\ []) do
+    request(client, "DescribeStackSummary", input, http_options)
   end
 
   @doc """
@@ -628,8 +628,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_stacks(client, input, options \\ []) do
-    request(client, "DescribeStacks", input, options)
+  def describe_stacks(client, input, http_options \\ []) do
+    request(client, "DescribeStacks", input, http_options)
   end
 
   @doc """
@@ -643,8 +643,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_time_based_auto_scaling(client, input, options \\ []) do
-    request(client, "DescribeTimeBasedAutoScaling", input, options)
+  def describe_time_based_auto_scaling(client, input, http_options \\ []) do
+    request(client, "DescribeTimeBasedAutoScaling", input, http_options)
   end
 
   @doc """
@@ -655,8 +655,8 @@ defmodule AWS.OpsWorks do
   user permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_user_profiles(client, input, options \\ []) do
-    request(client, "DescribeUserProfiles", input, options)
+  def describe_user_profiles(client, input, http_options \\ []) do
+    request(client, "DescribeUserProfiles", input, http_options)
   end
 
   @doc """
@@ -670,8 +670,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def describe_volumes(client, input, options \\ []) do
-    request(client, "DescribeVolumes", input, options)
+  def describe_volumes(client, input, http_options \\ []) do
+    request(client, "DescribeVolumes", input, http_options)
   end
 
   @doc """
@@ -683,8 +683,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def detach_elastic_load_balancer(client, input, options \\ []) do
-    request(client, "DetachElasticLoadBalancer", input, options)
+  def detach_elastic_load_balancer(client, input, http_options \\ []) do
+    request(client, "DetachElasticLoadBalancer", input, http_options)
   end
 
   @doc """
@@ -698,8 +698,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def disassociate_elastic_ip(client, input, options \\ []) do
-    request(client, "DisassociateElasticIp", input, options)
+  def disassociate_elastic_ip(client, input, http_options \\ []) do
+    request(client, "DisassociateElasticIp", input, http_options)
   end
 
   @doc """
@@ -712,16 +712,16 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def get_hostname_suggestion(client, input, options \\ []) do
-    request(client, "GetHostnameSuggestion", input, options)
+  def get_hostname_suggestion(client, input, http_options \\ []) do
+    request(client, "GetHostnameSuggestion", input, http_options)
   end
 
   @doc """
   <note>This action can be used only with Windows stacks.</note> Grants RDP
   access to a Windows instance for a specified time period.
   """
-  def grant_access(client, input, options \\ []) do
-    request(client, "GrantAccess", input, options)
+  def grant_access(client, input, http_options \\ []) do
+    request(client, "GrantAccess", input, http_options)
   end
 
   @doc """
@@ -735,8 +735,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def reboot_instance(client, input, options \\ []) do
-    request(client, "RebootInstance", input, options)
+  def reboot_instance(client, input, http_options \\ []) do
+    request(client, "RebootInstance", input, http_options)
   end
 
   @doc """
@@ -751,8 +751,8 @@ defmodule AWS.OpsWorks do
   see [ Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def register_ecs_cluster(client, input, options \\ []) do
-    request(client, "RegisterEcsCluster", input, options)
+  def register_ecs_cluster(client, input, http_options \\ []) do
+    request(client, "RegisterEcsCluster", input, http_options)
   end
 
   @doc """
@@ -768,8 +768,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def register_elastic_ip(client, input, options \\ []) do
-    request(client, "RegisterElasticIp", input, options)
+  def register_elastic_ip(client, input, http_options \\ []) do
+    request(client, "RegisterElasticIp", input, http_options)
   end
 
   @doc """
@@ -790,8 +790,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def register_instance(client, input, options \\ []) do
-    request(client, "RegisterInstance", input, options)
+  def register_instance(client, input, http_options \\ []) do
+    request(client, "RegisterInstance", input, http_options)
   end
 
   @doc """
@@ -803,8 +803,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def register_rds_db_instance(client, input, options \\ []) do
-    request(client, "RegisterRdsDbInstance", input, options)
+  def register_rds_db_instance(client, input, http_options \\ []) do
+    request(client, "RegisterRdsDbInstance", input, http_options)
   end
 
   @doc """
@@ -820,8 +820,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def register_volume(client, input, options \\ []) do
-    request(client, "RegisterVolume", input, options)
+  def register_volume(client, input, http_options \\ []) do
+    request(client, "RegisterVolume", input, http_options)
   end
 
   @doc """
@@ -840,8 +840,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def set_load_based_auto_scaling(client, input, options \\ []) do
-    request(client, "SetLoadBasedAutoScaling", input, options)
+  def set_load_based_auto_scaling(client, input, http_options \\ []) do
+    request(client, "SetLoadBasedAutoScaling", input, http_options)
   end
 
   @doc """
@@ -854,8 +854,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def set_permission(client, input, options \\ []) do
-    request(client, "SetPermission", input, options)
+  def set_permission(client, input, http_options \\ []) do
+    request(client, "SetPermission", input, http_options)
   end
 
   @doc """
@@ -869,8 +869,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def set_time_based_auto_scaling(client, input, options \\ []) do
-    request(client, "SetTimeBasedAutoScaling", input, options)
+  def set_time_based_auto_scaling(client, input, http_options \\ []) do
+    request(client, "SetTimeBasedAutoScaling", input, http_options)
   end
 
   @doc """
@@ -884,8 +884,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def start_instance(client, input, options \\ []) do
-    request(client, "StartInstance", input, options)
+  def start_instance(client, input, http_options \\ []) do
+    request(client, "StartInstance", input, http_options)
   end
 
   @doc """
@@ -897,8 +897,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def start_stack(client, input, options \\ []) do
-    request(client, "StartStack", input, options)
+  def start_stack(client, input, http_options \\ []) do
+    request(client, "StartStack", input, http_options)
   end
 
   @doc """
@@ -914,8 +914,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def stop_instance(client, input, options \\ []) do
-    request(client, "StopInstance", input, options)
+  def stop_instance(client, input, http_options \\ []) do
+    request(client, "StopInstance", input, http_options)
   end
 
   @doc """
@@ -927,8 +927,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def stop_stack(client, input, options \\ []) do
-    request(client, "StopStack", input, options)
+  def stop_stack(client, input, http_options \\ []) do
+    request(client, "StopStack", input, http_options)
   end
 
   @doc """
@@ -943,8 +943,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def unassign_instance(client, input, options \\ []) do
-    request(client, "UnassignInstance", input, options)
+  def unassign_instance(client, input, http_options \\ []) do
+    request(client, "UnassignInstance", input, http_options)
   end
 
   @doc """
@@ -958,8 +958,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def unassign_volume(client, input, options \\ []) do
-    request(client, "UnassignVolume", input, options)
+  def unassign_volume(client, input, http_options \\ []) do
+    request(client, "UnassignVolume", input, http_options)
   end
 
   @doc """
@@ -971,8 +971,8 @@ defmodule AWS.OpsWorks do
   permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_app(client, input, options \\ []) do
-    request(client, "UpdateApp", input, options)
+  def update_app(client, input, http_options \\ []) do
+    request(client, "UpdateApp", input, http_options)
   end
 
   @doc """
@@ -986,8 +986,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_elastic_ip(client, input, options \\ []) do
-    request(client, "UpdateElasticIp", input, options)
+  def update_elastic_ip(client, input, http_options \\ []) do
+    request(client, "UpdateElasticIp", input, http_options)
   end
 
   @doc """
@@ -999,8 +999,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_instance(client, input, options \\ []) do
-    request(client, "UpdateInstance", input, options)
+  def update_instance(client, input, http_options \\ []) do
+    request(client, "UpdateInstance", input, http_options)
   end
 
   @doc """
@@ -1012,8 +1012,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_layer(client, input, options \\ []) do
-    request(client, "UpdateLayer", input, options)
+  def update_layer(client, input, http_options \\ []) do
+    request(client, "UpdateLayer", input, http_options)
   end
 
   @doc """
@@ -1024,8 +1024,8 @@ defmodule AWS.OpsWorks do
   permissions. For more information on user permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_my_user_profile(client, input, options \\ []) do
-    request(client, "UpdateMyUserProfile", input, options)
+  def update_my_user_profile(client, input, http_options \\ []) do
+    request(client, "UpdateMyUserProfile", input, http_options)
   end
 
   @doc """
@@ -1037,8 +1037,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_rds_db_instance(client, input, options \\ []) do
-    request(client, "UpdateRdsDbInstance", input, options)
+  def update_rds_db_instance(client, input, http_options \\ []) do
+    request(client, "UpdateRdsDbInstance", input, http_options)
   end
 
   @doc """
@@ -1050,8 +1050,8 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_stack(client, input, options \\ []) do
-    request(client, "UpdateStack", input, options)
+  def update_stack(client, input, http_options \\ []) do
+    request(client, "UpdateStack", input, http_options)
   end
 
   @doc """
@@ -1062,8 +1062,8 @@ defmodule AWS.OpsWorks do
   user permissions, see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_user_profile(client, input, options \\ []) do
-    request(client, "UpdateUserProfile", input, options)
+  def update_user_profile(client, input, http_options \\ []) do
+    request(client, "UpdateUserProfile", input, http_options)
   end
 
   @doc """
@@ -1077,11 +1077,11 @@ defmodule AWS.OpsWorks do
   see [Managing User
   Permissions](http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html).
   """
-  def update_volume(client, input, options \\ []) do
-    request(client, "UpdateVolume", input, options)
+  def update_volume(client, input, http_options \\ []) do
+    request(client, "UpdateVolume", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "opsworks"}
     host = "opsworks.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -1090,12 +1090,12 @@ defmodule AWS.OpsWorks do
                {"X-Amz-Target", "OpsWorks_20130218.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/route53_domains.ex
+++ b/lib/aws/route53_domains.ex
@@ -12,8 +12,8 @@ defmodule AWS.Route53.Domains do
   domain is pending, you must submit another request to determine the
   availability of the domain name.
   """
-  def check_domain_availability(client, input, options \\ []) do
-    request(client, "CheckDomainAvailability", input, options)
+  def check_domain_availability(client, input, http_options \\ []) do
+    request(client, "CheckDomainAvailability", input, http_options)
   end
 
   @doc """
@@ -22,8 +22,8 @@ defmodule AWS.Route53.Domains do
   All tag operations are eventually consistent; subsequent operations may not
   immediately represent all issued operations.
   """
-  def delete_tags_for_domain(client, input, options \\ []) do
-    request(client, "DeleteTagsForDomain", input, options)
+  def delete_tags_for_domain(client, input, http_options \\ []) do
+    request(client, "DeleteTagsForDomain", input, http_options)
   end
 
   @doc """
@@ -35,8 +35,8 @@ defmodule AWS.Route53.Domains do
   renewed when the expiration date passes, and you will lose control of the
   domain name.</note>
   """
-  def disable_domain_auto_renew(client, input, options \\ []) do
-    request(client, "DisableDomainAutoRenew", input, options)
+  def disable_domain_auto_renew(client, input, http_options \\ []) do
+    request(client, "DisableDomainAutoRenew", input, http_options)
   end
 
   @doc """
@@ -48,8 +48,8 @@ defmodule AWS.Route53.Domains do
   the request is not completed successfully, the domain registrant will be
   notified by email.
   """
-  def disable_domain_transfer_lock(client, input, options \\ []) do
-    request(client, "DisableDomainTransferLock", input, options)
+  def disable_domain_transfer_lock(client, input, http_options \\ []) do
+    request(client, "DisableDomainTransferLock", input, http_options)
   end
 
   @doc """
@@ -65,8 +65,8 @@ defmodule AWS.Route53.Domains do
   renew before the end of the renewal period that is listed on the Gandi
   website so we can complete processing before the deadline.
   """
-  def enable_domain_auto_renew(client, input, options \\ []) do
-    request(client, "EnableDomainAutoRenew", input, options)
+  def enable_domain_auto_renew(client, input, http_options \\ []) do
+    request(client, "EnableDomainAutoRenew", input, http_options)
   end
 
   @doc """
@@ -76,40 +76,40 @@ defmodule AWS.Route53.Domains do
   and completion of the action. If the request is not completed successfully,
   the domain registrant will be notified by email.
   """
-  def enable_domain_transfer_lock(client, input, options \\ []) do
-    request(client, "EnableDomainTransferLock", input, options)
+  def enable_domain_transfer_lock(client, input, http_options \\ []) do
+    request(client, "EnableDomainTransferLock", input, http_options)
   end
 
   @doc """
   This operation returns detailed information about the domain. The domain's
   contact information is also returned as part of the output.
   """
-  def get_domain_detail(client, input, options \\ []) do
-    request(client, "GetDomainDetail", input, options)
+  def get_domain_detail(client, input, http_options \\ []) do
+    request(client, "GetDomainDetail", input, http_options)
   end
 
   @doc """
   This operation returns the current status of an operation that is not
   completed.
   """
-  def get_operation_detail(client, input, options \\ []) do
-    request(client, "GetOperationDetail", input, options)
+  def get_operation_detail(client, input, http_options \\ []) do
+    request(client, "GetOperationDetail", input, http_options)
   end
 
   @doc """
   This operation returns all the domain names registered with Amazon Route 53
   for the current AWS account.
   """
-  def list_domains(client, input, options \\ []) do
-    request(client, "ListDomains", input, options)
+  def list_domains(client, input, http_options \\ []) do
+    request(client, "ListDomains", input, http_options)
   end
 
   @doc """
   This operation returns the operation IDs of operations that are not yet
   complete.
   """
-  def list_operations(client, input, options \\ []) do
-    request(client, "ListOperations", input, options)
+  def list_operations(client, input, http_options \\ []) do
+    request(client, "ListOperations", input, http_options)
   end
 
   @doc """
@@ -119,8 +119,8 @@ defmodule AWS.Route53.Domains do
   All tag operations are eventually consistent; subsequent operations may not
   immediately represent all issued operations.
   """
-  def list_tags_for_domain(client, input, options \\ []) do
-    request(client, "ListTagsForDomain", input, options)
+  def list_tags_for_domain(client, input, http_options \\ []) do
+    request(client, "ListTagsForDomain", input, http_options)
   end
 
   @doc """
@@ -146,16 +146,16 @@ defmodule AWS.Route53.Domains do
   more information, see [Amazon Route 53
   Pricing](http://aws.amazon.com/route53/pricing/).</li> </ul>
   """
-  def register_domain(client, input, options \\ []) do
-    request(client, "RegisterDomain", input, options)
+  def register_domain(client, input, http_options \\ []) do
+    request(client, "RegisterDomain", input, http_options)
   end
 
   @doc """
   This operation returns the AuthCode for the domain. To transfer a domain to
   another registrar, you provide this value to the new registrar.
   """
-  def retrieve_domain_auth_code(client, input, options \\ []) do
-    request(client, "RetrieveDomainAuthCode", input, options)
+  def retrieve_domain_auth_code(client, input, http_options \\ []) do
+    request(client, "RetrieveDomainAuthCode", input, http_options)
   end
 
   @doc """
@@ -185,8 +185,8 @@ defmodule AWS.Route53.Domains do
   completion of the action. If the transfer doesn't complete successfully,
   the domain registrant will be notified by email.
   """
-  def transfer_domain(client, input, options \\ []) do
-    request(client, "TransferDomain", input, options)
+  def transfer_domain(client, input, http_options \\ []) do
+    request(client, "TransferDomain", input, http_options)
   end
 
   @doc """
@@ -199,8 +199,8 @@ defmodule AWS.Route53.Domains do
   is not completed successfully, the domain registrant will be notified by
   email.
   """
-  def update_domain_contact(client, input, options \\ []) do
-    request(client, "UpdateDomainContact", input, options)
+  def update_domain_contact(client, input, http_options \\ []) do
+    request(client, "UpdateDomainContact", input, http_options)
   end
 
   @doc """
@@ -217,8 +217,8 @@ defmodule AWS.Route53.Domains do
   and completion of the action. If the request is not completed successfully,
   the domain registrant will be notified by email.
   """
-  def update_domain_contact_privacy(client, input, options \\ []) do
-    request(client, "UpdateDomainContactPrivacy", input, options)
+  def update_domain_contact_privacy(client, input, http_options \\ []) do
+    request(client, "UpdateDomainContactPrivacy", input, http_options)
   end
 
   @doc """
@@ -231,8 +231,8 @@ defmodule AWS.Route53.Domains do
   track the progress and completion of the action. If the request is not
   completed successfully, the domain registrant will be notified by email.
   """
-  def update_domain_nameservers(client, input, options \\ []) do
-    request(client, "UpdateDomainNameservers", input, options)
+  def update_domain_nameservers(client, input, http_options \\ []) do
+    request(client, "UpdateDomainNameservers", input, http_options)
   end
 
   @doc """
@@ -241,11 +241,11 @@ defmodule AWS.Route53.Domains do
   All tag operations are eventually consistent; subsequent operations may not
   immediately represent all issued operations.
   """
-  def update_tags_for_domain(client, input, options \\ []) do
-    request(client, "UpdateTagsForDomain", input, options)
+  def update_tags_for_domain(client, input, http_options \\ []) do
+    request(client, "UpdateTagsForDomain", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "route53domains"}
     host = "route53domains.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -254,12 +254,12 @@ defmodule AWS.Route53.Domains do
                {"X-Amz-Target", "Route53Domains_v20140515.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/ssm.ex
+++ b/lib/aws/ssm.ex
@@ -34,8 +34,8 @@ defmodule AWS.SSM do
   an associated configuration document, we replace the current configuration
   document with the new configuration document.
   """
-  def create_association(client, input, options \\ []) do
-    request(client, "CreateAssociation", input, options)
+  def create_association(client, input, http_options \\ []) do
+    request(client, "CreateAssociation", input, http_options)
   end
 
   @doc """
@@ -50,8 +50,8 @@ defmodule AWS.SSM do
   an associated configuration document, we replace the current configuration
   document with the new configuration document.
   """
-  def create_association_batch(client, input, options \\ []) do
-    request(client, "CreateAssociationBatch", input, options)
+  def create_association_batch(client, input, http_options \\ []) do
+    request(client, "CreateAssociationBatch", input, http_options)
   end
 
   @doc """
@@ -60,8 +60,8 @@ defmodule AWS.SSM do
   After you create a configuration document, you can use `CreateAssociation`
   to associate it with one or more running instances.
   """
-  def create_document(client, input, options \\ []) do
-    request(client, "CreateDocument", input, options)
+  def create_document(client, input, http_options \\ []) do
+    request(client, "CreateDocument", input, http_options)
   end
 
   @doc """
@@ -74,8 +74,8 @@ defmodule AWS.SSM do
   must create a new configuration document with the desired configuration and
   associate it with the instance.
   """
-  def delete_association(client, input, options \\ []) do
-    request(client, "DeleteAssociation", input, options)
+  def delete_association(client, input, http_options \\ []) do
+    request(client, "DeleteAssociation", input, http_options)
   end
 
   @doc """
@@ -84,56 +84,56 @@ defmodule AWS.SSM do
   You must use `DeleteAssociation` to disassociate all instances that are
   associated with the configuration document before you can delete it.
   """
-  def delete_document(client, input, options \\ []) do
-    request(client, "DeleteDocument", input, options)
+  def delete_document(client, input, http_options \\ []) do
+    request(client, "DeleteDocument", input, http_options)
   end
 
   @doc """
   Describes the associations for the specified configuration document or
   instance.
   """
-  def describe_association(client, input, options \\ []) do
-    request(client, "DescribeAssociation", input, options)
+  def describe_association(client, input, http_options \\ []) do
+    request(client, "DescribeAssociation", input, http_options)
   end
 
   @doc """
   Describes the specified configuration document.
   """
-  def describe_document(client, input, options \\ []) do
-    request(client, "DescribeDocument", input, options)
+  def describe_document(client, input, http_options \\ []) do
+    request(client, "DescribeDocument", input, http_options)
   end
 
   @doc """
   Gets the contents of the specified configuration document.
   """
-  def get_document(client, input, options \\ []) do
-    request(client, "GetDocument", input, options)
+  def get_document(client, input, http_options \\ []) do
+    request(client, "GetDocument", input, http_options)
   end
 
   @doc """
   Lists the associations for the specified configuration document or
   instance.
   """
-  def list_associations(client, input, options \\ []) do
-    request(client, "ListAssociations", input, options)
+  def list_associations(client, input, http_options \\ []) do
+    request(client, "ListAssociations", input, http_options)
   end
 
   @doc """
   Describes one or more of your configuration documents.
   """
-  def list_documents(client, input, options \\ []) do
-    request(client, "ListDocuments", input, options)
+  def list_documents(client, input, http_options \\ []) do
+    request(client, "ListDocuments", input, http_options)
   end
 
   @doc """
   Updates the status of the configuration document associated with the
   specified instance.
   """
-  def update_association_status(client, input, options \\ []) do
-    request(client, "UpdateAssociationStatus", input, options)
+  def update_association_status(client, input, http_options \\ []) do
+    request(client, "UpdateAssociationStatus", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "ssm"}
     host = "ssm.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -142,12 +142,12 @@ defmodule AWS.SSM do
                {"X-Amz-Target", "AmazonSSM.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/storage_gateway.ex
+++ b/lib/aws/storage_gateway.ex
@@ -46,8 +46,8 @@ defmodule AWS.StorageGateway do
   <note>You must turn on the gateway VM before you can activate your
   gateway.</note>
   """
-  def activate_gateway(client, input, options \\ []) do
-    request(client, "ActivateGateway", input, options)
+  def activate_gateway(client, input, http_options \\ []) do
+    request(client, "ActivateGateway", input, http_options)
   end
 
   @doc """
@@ -60,8 +60,8 @@ defmodule AWS.StorageGateway do
   you want to add cache, and one or more disk IDs that you want to configure
   as cache.
   """
-  def add_cache(client, input, options \\ []) do
-    request(client, "AddCache", input, options)
+  def add_cache(client, input, http_options \\ []) do
+    request(client, "AddCache", input, http_options)
   end
 
   @doc """
@@ -73,8 +73,8 @@ defmodule AWS.StorageGateway do
   you want to add upload buffer, and one or more disk IDs that you want to
   configure as upload buffer.
   """
-  def add_upload_buffer(client, input, options \\ []) do
-    request(client, "AddUploadBuffer", input, options)
+  def add_upload_buffer(client, input, http_options \\ []) do
+    request(client, "AddUploadBuffer", input, http_options)
   end
 
   @doc """
@@ -91,16 +91,16 @@ defmodule AWS.StorageGateway do
   to which you want to add working storage, and one or more disk IDs that you
   want to configure as working storage.
   """
-  def add_working_storage(client, input, options \\ []) do
-    request(client, "AddWorkingStorage", input, options)
+  def add_working_storage(client, input, http_options \\ []) do
+    request(client, "AddWorkingStorage", input, http_options)
   end
 
   @doc """
   Cancels archiving of a virtual tape to the virtual tape shelf (VTS) after
   the archiving process is initiated.
   """
-  def cancel_archival(client, input, options \\ []) do
-    request(client, "CancelArchival", input, options)
+  def cancel_archival(client, input, http_options \\ []) do
+    request(client, "CancelArchival", input, http_options)
   end
 
   @doc """
@@ -108,8 +108,8 @@ defmodule AWS.StorageGateway do
   gateway after the retrieval process is initiated. The virtual tape is
   returned to the VTS.
   """
-  def cancel_retrieval(client, input, options \\ []) do
-    request(client, "CancelRetrieval", input, options)
+  def cancel_retrieval(client, input, http_options \\ []) do
+    request(client, "CancelRetrieval", input, http_options)
   end
 
   @doc """
@@ -125,8 +125,8 @@ defmodule AWS.StorageGateway do
   Amazon Resource Name (ARN), its size, and the iSCSI target ARN that
   initiators can use to connect to the volume target.
   """
-  def create_cached_iscsi_volume(client, input, options \\ []) do
-    request(client, "CreateCachediSCSIVolume", input, options)
+  def create_cached_iscsi_volume(client, input, http_options \\ []) do
+    request(client, "CreateCachediSCSIVolume", input, http_options)
   end
 
   @doc """
@@ -153,8 +153,8 @@ defmodule AWS.StorageGateway do
   more information, see DescribeSnapshots or DeleteSnapshot in the [EC2 API
   reference](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Operations.html).</note>
   """
-  def create_snapshot(client, input, options \\ []) do
-    request(client, "CreateSnapshot", input, options)
+  def create_snapshot(client, input, http_options \\ []) do
+    request(client, "CreateSnapshot", input, http_options)
   end
 
   @doc """
@@ -180,8 +180,8 @@ defmodule AWS.StorageGateway do
 
   </note>
   """
-  def create_snapshot_from_volume_recovery_point(client, input, options \\ []) do
-    request(client, "CreateSnapshotFromVolumeRecoveryPoint", input, options)
+  def create_snapshot_from_volume_recovery_point(client, input, http_options \\ []) do
+    request(client, "CreateSnapshotFromVolumeRecoveryPoint", input, http_options)
   end
 
   @doc """
@@ -199,8 +199,8 @@ defmodule AWS.StorageGateway do
   Resource Name (ARN), its size, and the iSCSI target ARN that initiators can
   use to connect to the volume target.
   """
-  def create_stored_iscsi_volume(client, input, options \\ []) do
-    request(client, "CreateStorediSCSIVolume", input, options)
+  def create_stored_iscsi_volume(client, input, http_options \\ []) do
+    request(client, "CreateStorediSCSIVolume", input, http_options)
   end
 
   @doc """
@@ -211,8 +211,8 @@ defmodule AWS.StorageGateway do
   virtual tapes. Use the `AddCache` operation to add cache storage to a
   gateway. </note>
   """
-  def create_tapes(client, input, options \\ []) do
-    request(client, "CreateTapes", input, options)
+  def create_tapes(client, input, http_options \\ []) do
+    request(client, "CreateTapes", input, http_options)
   end
 
   @doc """
@@ -222,16 +222,16 @@ defmodule AWS.StorageGateway do
   unchanged. To specify which gateway to work with, use the Amazon Resource
   Name (ARN) of the gateway in your request.
   """
-  def delete_bandwidth_rate_limit(client, input, options \\ []) do
-    request(client, "DeleteBandwidthRateLimit", input, options)
+  def delete_bandwidth_rate_limit(client, input, http_options \\ []) do
+    request(client, "DeleteBandwidthRateLimit", input, http_options)
   end
 
   @doc """
   This operation deletes Challenge-Handshake Authentication Protocol (CHAP)
   credentials for a specified iSCSI target and initiator pair.
   """
-  def delete_chap_credentials(client, input, options \\ []) do
-    request(client, "DeleteChapCredentials", input, options)
+  def delete_chap_credentials(client, input, http_options \\ []) do
+    request(client, "DeleteChapCredentials", input, http_options)
   end
 
   @doc """
@@ -255,8 +255,8 @@ defmodule AWS.StorageGateway do
 
   </important>
   """
-  def delete_gateway(client, input, options \\ []) do
-    request(client, "DeleteGateway", input, options)
+  def delete_gateway(client, input, http_options \\ []) do
+    request(client, "DeleteGateway", input, http_options)
   end
 
   @doc """
@@ -274,22 +274,22 @@ defmodule AWS.StorageGateway do
 
   </note>
   """
-  def delete_snapshot_schedule(client, input, options \\ []) do
-    request(client, "DeleteSnapshotSchedule", input, options)
+  def delete_snapshot_schedule(client, input, http_options \\ []) do
+    request(client, "DeleteSnapshotSchedule", input, http_options)
   end
 
   @doc """
   Deletes the specified virtual tape.
   """
-  def delete_tape(client, input, options \\ []) do
-    request(client, "DeleteTape", input, options)
+  def delete_tape(client, input, http_options \\ []) do
+    request(client, "DeleteTape", input, http_options)
   end
 
   @doc """
   Deletes the specified virtual tape from the virtual tape shelf (VTS).
   """
-  def delete_tape_archive(client, input, options \\ []) do
-    request(client, "DeleteTapeArchive", input, options)
+  def delete_tape_archive(client, input, http_options \\ []) do
+    request(client, "DeleteTapeArchive", input, http_options)
   end
 
   @doc """
@@ -309,8 +309,8 @@ defmodule AWS.StorageGateway do
   In the request, you must provide the Amazon Resource Name (ARN) of the
   storage volume you want to delete.
   """
-  def delete_volume(client, input, options \\ []) do
-    request(client, "DeleteVolume", input, options)
+  def delete_volume(client, input, http_options \\ []) do
+    request(client, "DeleteVolume", input, http_options)
   end
 
   @doc """
@@ -324,8 +324,8 @@ defmodule AWS.StorageGateway do
   to describe, use the Amazon Resource Name (ARN) of the gateway in your
   request.
   """
-  def describe_bandwidth_rate_limit(client, input, options \\ []) do
-    request(client, "DescribeBandwidthRateLimit", input, options)
+  def describe_bandwidth_rate_limit(client, input, http_options \\ []) do
+    request(client, "DescribeBandwidthRateLimit", input, http_options)
   end
 
   @doc """
@@ -335,8 +335,8 @@ defmodule AWS.StorageGateway do
   The response includes disk IDs that are configured as cache, and it
   includes the amount of cache allocated and used.
   """
-  def describe_cache(client, input, options \\ []) do
-    request(client, "DescribeCache", input, options)
+  def describe_cache(client, input, http_options \\ []) do
+    request(client, "DescribeCache", input, http_options)
   end
 
   @doc """
@@ -348,8 +348,8 @@ defmodule AWS.StorageGateway do
   response Amazon Storage Gateway returns volume information sorted by volume
   Amazon Resource Name (ARN).
   """
-  def describe_cached_iscsi_volumes(client, input, options \\ []) do
-    request(client, "DescribeCachediSCSIVolumes", input, options)
+  def describe_cached_iscsi_volumes(client, input, http_options \\ []) do
+    request(client, "DescribeCachediSCSIVolumes", input, http_options)
   end
 
   @doc """
@@ -357,8 +357,8 @@ defmodule AWS.StorageGateway do
   Protocol (CHAP) credentials information for a specified iSCSI target, one
   for each target-initiator pair.
   """
-  def describe_chap_credentials(client, input, options \\ []) do
-    request(client, "DescribeChapCredentials", input, options)
+  def describe_chap_credentials(client, input, http_options \\ []) do
+    request(client, "DescribeChapCredentials", input, http_options)
   end
 
   @doc """
@@ -367,8 +367,8 @@ defmodule AWS.StorageGateway do
   running or not). To specify which gateway to describe, use the Amazon
   Resource Name (ARN) of the gateway in your request.
   """
-  def describe_gateway_information(client, input, options \\ []) do
-    request(client, "DescribeGatewayInformation", input, options)
+  def describe_gateway_information(client, input, http_options \\ []) do
+    request(client, "DescribeGatewayInformation", input, http_options)
   end
 
   @doc """
@@ -376,8 +376,8 @@ defmodule AWS.StorageGateway do
   including the day and time of the week. Note that values are in terms of
   the gateway's time zone.
   """
-  def describe_maintenance_start_time(client, input, options \\ []) do
-    request(client, "DescribeMaintenanceStartTime", input, options)
+  def describe_maintenance_start_time(client, input, http_options \\ []) do
+    request(client, "DescribeMaintenanceStartTime", input, http_options)
   end
 
   @doc """
@@ -385,8 +385,8 @@ defmodule AWS.StorageGateway do
   volume. The snapshot schedule information includes intervals at which
   snapshots are automatically initiated on the volume.
   """
-  def describe_snapshot_schedule(client, input, options \\ []) do
-    request(client, "DescribeSnapshotSchedule", input, options)
+  def describe_snapshot_schedule(client, input, http_options \\ []) do
+    request(client, "DescribeSnapshotSchedule", input, http_options)
   end
 
   @doc """
@@ -395,8 +395,8 @@ defmodule AWS.StorageGateway do
   gateway. In the response Amazon Storage Gateway returns volume information
   sorted by volume ARNs.
   """
-  def describe_stored_iscsi_volumes(client, input, options \\ []) do
-    request(client, "DescribeStorediSCSIVolumes", input, options)
+  def describe_stored_iscsi_volumes(client, input, http_options \\ []) do
+    request(client, "DescribeStorediSCSIVolumes", input, http_options)
   end
 
   @doc """
@@ -407,8 +407,8 @@ defmodule AWS.StorageGateway do
   description of all virtual tapes found in the VTS associated with your
   account.
   """
-  def describe_tape_archives(client, input, options \\ []) do
-    request(client, "DescribeTapeArchives", input, options)
+  def describe_tape_archives(client, input, http_options \\ []) do
+    request(client, "DescribeTapeArchives", input, http_options)
   end
 
   @doc """
@@ -419,8 +419,8 @@ defmodule AWS.StorageGateway do
   data on the virtual tape is consistent. If your gateway crashes, virtual
   tapes that have recovery points can be recovered to a new gateway.
   """
-  def describe_tape_recovery_points(client, input, options \\ []) do
-    request(client, "DescribeTapeRecoveryPoints", input, options)
+  def describe_tape_recovery_points(client, input, http_options \\ []) do
+    request(client, "DescribeTapeRecoveryPoints", input, http_options)
   end
 
   @doc """
@@ -428,8 +428,8 @@ defmodule AWS.StorageGateway do
   virtual tapes. If a `TapeARN` is not specified, returns a description of
   all virtual tapes associated with the specified gateway.
   """
-  def describe_tapes(client, input, options \\ []) do
-    request(client, "DescribeTapes", input, options)
+  def describe_tapes(client, input, http_options \\ []) do
+    request(client, "DescribeTapes", input, http_options)
   end
 
   @doc """
@@ -440,8 +440,8 @@ defmodule AWS.StorageGateway do
   The response includes disk IDs that are configured as upload buffer space,
   and it includes the amount of upload buffer space allocated and used.
   """
-  def describe_upload_buffer(client, input, options \\ []) do
-    request(client, "DescribeUploadBuffer", input, options)
+  def describe_upload_buffer(client, input, http_options \\ []) do
+    request(client, "DescribeUploadBuffer", input, http_options)
   end
 
   @doc """
@@ -451,8 +451,8 @@ defmodule AWS.StorageGateway do
 
   The list of VTL devices must be from one gateway.
   """
-  def describe_vtl_devices(client, input, options \\ []) do
-    request(client, "DescribeVTLDevices", input, options)
+  def describe_vtl_devices(client, input, http_options \\ []) do
+    request(client, "DescribeVTLDevices", input, http_options)
   end
 
   @doc """
@@ -468,8 +468,8 @@ defmodule AWS.StorageGateway do
   </note> The response includes disk IDs that are configured as working
   storage, and it includes the amount of working storage allocated and used.
   """
-  def describe_working_storage(client, input, options \\ []) do
-    request(client, "DescribeWorkingStorage", input, options)
+  def describe_working_storage(client, input, http_options \\ []) do
+    request(client, "DescribeWorkingStorage", input, http_options)
   end
 
   @doc """
@@ -482,8 +482,8 @@ defmodule AWS.StorageGateway do
 
   <important>Once a gateway is disabled it cannot be enabled.</important>
   """
-  def disable_gateway(client, input, options \\ []) do
-    request(client, "DisableGateway", input, options)
+  def disable_gateway(client, input, http_options \\ []) do
+    request(client, "DisableGateway", input, http_options)
   end
 
   @doc """
@@ -500,8 +500,8 @@ defmodule AWS.StorageGateway do
   contains a marker that you can specify in your next request to fetch the
   next page of gateways.
   """
-  def list_gateways(client, input, options \\ []) do
-    request(client, "ListGateways", input, options)
+  def list_gateways(client, input, http_options \\ []) do
+    request(client, "ListGateways", input, http_options)
   end
 
   @doc """
@@ -516,16 +516,16 @@ defmodule AWS.StorageGateway do
   connected to the gateway), or mismatch (the disk node is occupied by a disk
   that has incorrect metadata or the disk content is corrupted).
   """
-  def list_local_disks(client, input, options \\ []) do
-    request(client, "ListLocalDisks", input, options)
+  def list_local_disks(client, input, http_options \\ []) do
+    request(client, "ListLocalDisks", input, http_options)
   end
 
   @doc """
   This operation lists iSCSI initiators that are connected to a volume. You
   can use this operation to determine whether a volume is being used or not.
   """
-  def list_volume_initiators(client, input, options \\ []) do
-    request(client, "ListVolumeInitiators", input, options)
+  def list_volume_initiators(client, input, http_options \\ []) do
+    request(client, "ListVolumeInitiators", input, http_options)
   end
 
   @doc """
@@ -537,8 +537,8 @@ defmodule AWS.StorageGateway do
   which you can create a snapshot. To create a snapshot from a volume
   recovery point use the `CreateSnapshotFromVolumeRecoveryPoint` operation.
   """
-  def list_volume_recovery_points(client, input, options \\ []) do
-    request(client, "ListVolumeRecoveryPoints", input, options)
+  def list_volume_recovery_points(client, input, http_options \\ []) do
+    request(client, "ListVolumeRecoveryPoints", input, http_options)
   end
 
   @doc """
@@ -554,8 +554,8 @@ defmodule AWS.StorageGateway do
   Marker field. You can use this Marker value in your subsequent request to
   retrieve the next set of volumes.
   """
-  def list_volumes(client, input, options \\ []) do
-    request(client, "ListVolumes", input, options)
+  def list_volumes(client, input, http_options \\ []) do
+    request(client, "ListVolumes", input, http_options)
   end
 
   @doc """
@@ -575,8 +575,8 @@ defmodule AWS.StorageGateway do
 
   </important>
   """
-  def reset_cache(client, input, options \\ []) do
-    request(client, "ResetCache", input, options)
+  def reset_cache(client, input, http_options \\ []) do
+    request(client, "ResetCache", input, http_options)
   end
 
   @doc """
@@ -589,8 +589,8 @@ defmodule AWS.StorageGateway do
   again to another gateway. You must archive the tape again before you can
   retrieve it to another gateway.
   """
-  def retrieve_tape_archive(client, input, options \\ []) do
-    request(client, "RetrieveTapeArchive", input, options)
+  def retrieve_tape_archive(client, input, http_options \\ []) do
+    request(client, "RetrieveTapeArchive", input, http_options)
   end
 
   @doc """
@@ -604,8 +604,8 @@ defmodule AWS.StorageGateway do
   tape is read-only. The virtual tape can be retrieved to only a gateway-VTL.
   There is no charge for retrieving recovery points.</note>
   """
-  def retrieve_tape_recovery_point(client, input, options \\ []) do
-    request(client, "RetrieveTapeRecoveryPoint", input, options)
+  def retrieve_tape_recovery_point(client, input, http_options \\ []) do
+    request(client, "RetrieveTapeRecoveryPoint", input, http_options)
   end
 
   @doc """
@@ -632,8 +632,8 @@ defmodule AWS.StorageGateway do
   `DeleteGateway`) to no longer pay software charges associated with the
   gateway.
   """
-  def shutdown_gateway(client, input, options \\ []) do
-    request(client, "ShutdownGateway", input, options)
+  def shutdown_gateway(client, input, http_options \\ []) do
+    request(client, "ShutdownGateway", input, http_options)
   end
 
   @doc """
@@ -649,8 +649,8 @@ defmodule AWS.StorageGateway do
   `ActivateGateway`.</note> To specify which gateway to start, use the Amazon
   Resource Name (ARN) of the gateway in your request.
   """
-  def start_gateway(client, input, options \\ []) do
-    request(client, "StartGateway", input, options)
+  def start_gateway(client, input, http_options \\ []) do
+    request(client, "StartGateway", input, http_options)
   end
 
   @doc """
@@ -666,8 +666,8 @@ defmodule AWS.StorageGateway do
   To specify which gateway to update, use the Amazon Resource Name (ARN) of
   the gateway in your request.
   """
-  def update_bandwidth_rate_limit(client, input, options \\ []) do
-    request(client, "UpdateBandwidthRateLimit", input, options)
+  def update_bandwidth_rate_limit(client, input, http_options \\ []) do
+    request(client, "UpdateBandwidthRateLimit", input, http_options)
   end
 
   @doc """
@@ -681,8 +681,8 @@ defmodule AWS.StorageGateway do
 
   </important>
   """
-  def update_chap_credentials(client, input, options \\ []) do
-    request(client, "UpdateChapCredentials", input, options)
+  def update_chap_credentials(client, input, http_options \\ []) do
+    request(client, "UpdateChapCredentials", input, http_options)
   end
 
   @doc """
@@ -690,8 +690,8 @@ defmodule AWS.StorageGateway do
   name and time zone. To specify which gateway to update, use the Amazon
   Resource Name (ARN) of the gateway in your request.
   """
-  def update_gateway_information(client, input, options \\ []) do
-    request(client, "UpdateGatewayInformation", input, options)
+  def update_gateway_information(client, input, http_options \\ []) do
+    request(client, "UpdateGatewayInformation", input, http_options)
   end
 
   @doc """
@@ -711,8 +711,8 @@ defmodule AWS.StorageGateway do
   Settings](http://docs.aws.amazon.com/storagegateway/latest/userguide/ConfiguringiSCSIClientInitiatorRedHatClient.html#CustomizeLinuxiSCSISettings),
   respectively.</important>
   """
-  def update_gateway_software_now(client, input, options \\ []) do
-    request(client, "UpdateGatewaySoftwareNow", input, options)
+  def update_gateway_software_now(client, input, http_options \\ []) do
+    request(client, "UpdateGatewaySoftwareNow", input, http_options)
   end
 
   @doc """
@@ -720,8 +720,8 @@ defmodule AWS.StorageGateway do
   information, including day and time of the week. The maintenance time is
   the time in your gateway's time zone.
   """
-  def update_maintenance_start_time(client, input, options \\ []) do
-    request(client, "UpdateMaintenanceStartTime", input, options)
+  def update_maintenance_start_time(client, input, http_options \\ []) do
+    request(client, "UpdateMaintenanceStartTime", input, http_options)
   end
 
   @doc """
@@ -735,8 +735,8 @@ defmodule AWS.StorageGateway do
   you want to update, and the schedule information, including when you want
   the snapshot to begin on a day and the frequency (in hours) of snapshots.
   """
-  def update_snapshot_schedule(client, input, options \\ []) do
-    request(client, "UpdateSnapshotSchedule", input, options)
+  def update_snapshot_schedule(client, input, http_options \\ []) do
+    request(client, "UpdateSnapshotSchedule", input, http_options)
   end
 
   @doc """
@@ -745,11 +745,11 @@ defmodule AWS.StorageGateway do
   gateway-VTL. This operation enables you to select a different type of
   medium changer after a gateway-VTL is activated.
   """
-  def update_vtl_device_type(client, input, options \\ []) do
-    request(client, "UpdateVTLDeviceType", input, options)
+  def update_vtl_device_type(client, input, http_options \\ []) do
+    request(client, "UpdateVTLDeviceType", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "storagegateway"}
     host = "storagegateway.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -758,12 +758,12 @@ defmodule AWS.StorageGateway do
                {"X-Amz-Target", "StorageGateway_20130630.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/support.ex
+++ b/lib/aws/support.ex
@@ -61,8 +61,8 @@ defmodule AWS.Support do
   when the set expires. The maximum number of attachments in a set is 3, and
   the maximum size of any attachment in the set is 5 MB.
   """
-  def add_attachments_to_set(client, input, options \\ []) do
-    request(client, "AddAttachmentsToSet", input, options)
+  def add_attachments_to_set(client, input, http_options \\ []) do
+    request(client, "AddAttachmentsToSet", input, http_options)
   end
 
   @doc """
@@ -77,8 +77,8 @@ defmodule AWS.Support do
   This operation implements a subset of the features of the AWS Support
   Center.
   """
-  def add_communication_to_case(client, input, options \\ []) do
-    request(client, "AddCommunicationToCase", input, options)
+  def add_communication_to_case(client, input, http_options \\ []) do
+    request(client, "AddCommunicationToCase", input, http_options)
   end
 
   @doc """
@@ -121,8 +121,8 @@ defmodule AWS.Support do
   number. Case numbers are used by the `DescribeCases` operation to retrieve
   existing AWS Support cases.
   """
-  def create_case(client, input, options \\ []) do
-    request(client, "CreateCase", input, options)
+  def create_case(client, input, http_options \\ []) do
+    request(client, "CreateCase", input, http_options)
   end
 
   @doc """
@@ -132,8 +132,8 @@ defmodule AWS.Support do
   `AttachmentDetails` objects that are returned by the
   `DescribeCommunications` operation.
   """
-  def describe_attachment(client, input, options \\ []) do
-    request(client, "DescribeAttachment", input, options)
+  def describe_attachment(client, input, http_options \\ []) do
+    request(client, "DescribeAttachment", input, http_options)
   end
 
   @doc """
@@ -152,8 +152,8 @@ defmodule AWS.Support do
   `NextToken` values, which specify where to paginate the returned records
   represented by the `CaseDetails` objects.</li> </ol>
   """
-  def describe_cases(client, input, options \\ []) do
-    request(client, "DescribeCases", input, options)
+  def describe_cases(client, input, http_options \\ []) do
+    request(client, "DescribeCases", input, http_options)
   end
 
   @doc """
@@ -170,8 +170,8 @@ defmodule AWS.Support do
   want displayed on each page, and use `NextToken` to specify the resumption
   of pagination.
   """
-  def describe_communications(client, input, options \\ []) do
-    request(client, "DescribeCommunications", input, options)
+  def describe_communications(client, input, http_options \\ []) do
+    request(client, "DescribeCommunications", input, http_options)
   end
 
   @doc """
@@ -189,8 +189,8 @@ defmodule AWS.Support do
   ensures that you always have the most recent set of service and category
   codes.
   """
-  def describe_services(client, input, options \\ []) do
-    request(client, "DescribeServices", input, options)
+  def describe_services(client, input, http_options \\ []) do
+    request(client, "DescribeServices", input, http_options)
   end
 
   @doc """
@@ -198,8 +198,8 @@ defmodule AWS.Support do
   case. The severity level for a case is also a field in the `CaseDetails`
   data type included in any `CreateCase` request.
   """
-  def describe_severity_levels(client, input, options \\ []) do
-    request(client, "DescribeSeverityLevels", input, options)
+  def describe_severity_levels(client, input, http_options \\ []) do
+    request(client, "DescribeSeverityLevels", input, http_options)
   end
 
   @doc """
@@ -207,8 +207,8 @@ defmodule AWS.Support do
   specified check IDs. Check IDs can be obtained by calling
   `DescribeTrustedAdvisorChecks`.
   """
-  def describe_trusted_advisor_check_refresh_statuses(client, input, options \\ []) do
-    request(client, "DescribeTrustedAdvisorCheckRefreshStatuses", input, options)
+  def describe_trusted_advisor_check_refresh_statuses(client, input, http_options \\ []) do
+    request(client, "DescribeTrustedAdvisorCheckRefreshStatuses", input, http_options)
   end
 
   @doc """
@@ -229,8 +229,8 @@ defmodule AWS.Support do
   **Timestamp.** The time of the last refresh of the check.</li> <li>
   **CheckId.** The unique identifier for the check.</li> </ul>
   """
-  def describe_trusted_advisor_check_result(client, input, options \\ []) do
-    request(client, "DescribeTrustedAdvisorCheckResult", input, options)
+  def describe_trusted_advisor_check_result(client, input, http_options \\ []) do
+    request(client, "DescribeTrustedAdvisorCheckResult", input, http_options)
   end
 
   @doc """
@@ -240,8 +240,8 @@ defmodule AWS.Support do
 
   The response contains an array of `TrustedAdvisorCheckSummary` objects.
   """
-  def describe_trusted_advisor_check_summaries(client, input, options \\ []) do
-    request(client, "DescribeTrustedAdvisorCheckSummaries", input, options)
+  def describe_trusted_advisor_check_summaries(client, input, http_options \\ []) do
+    request(client, "DescribeTrustedAdvisorCheckSummaries", input, http_options)
   end
 
   @doc """
@@ -250,8 +250,8 @@ defmodule AWS.Support do
   code; English ("en") and Japanese ("ja") are currently supported. The
   response contains a `TrustedAdvisorCheckDescription` for each check.
   """
-  def describe_trusted_advisor_checks(client, input, options \\ []) do
-    request(client, "DescribeTrustedAdvisorChecks", input, options)
+  def describe_trusted_advisor_checks(client, input, http_options \\ []) do
+    request(client, "DescribeTrustedAdvisorChecks", input, http_options)
   end
 
   @doc """
@@ -268,19 +268,19 @@ defmodule AWS.Support do
   the check is eligible for refresh.</li> <li> **CheckId.** The unique
   identifier for the check.</li> </ul>
   """
-  def refresh_trusted_advisor_check(client, input, options \\ []) do
-    request(client, "RefreshTrustedAdvisorCheck", input, options)
+  def refresh_trusted_advisor_check(client, input, http_options \\ []) do
+    request(client, "RefreshTrustedAdvisorCheck", input, http_options)
   end
 
   @doc """
   Takes a `CaseId` and returns the initial state of the case along with the
   state of the case after the call to `ResolveCase` completed.
   """
-  def resolve_case(client, input, options \\ []) do
-    request(client, "ResolveCase", input, options)
+  def resolve_case(client, input, http_options \\ []) do
+    request(client, "ResolveCase", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "support"}
     host = "support.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -289,12 +289,12 @@ defmodule AWS.Support do
                {"X-Amz-Target", "AWSSupport_20130415.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/swf.ex
+++ b/lib/aws/swf.ex
@@ -47,8 +47,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def count_closed_workflow_executions(client, input, options \\ []) do
-    request(client, "CountClosedWorkflowExecutions", input, options)
+  def count_closed_workflow_executions(client, input, http_options \\ []) do
+    request(client, "CountClosedWorkflowExecutions", input, http_options)
   end
 
   @doc """
@@ -77,8 +77,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def count_open_workflow_executions(client, input, options \\ []) do
-    request(client, "CountOpenWorkflowExecutions", input, options)
+  def count_open_workflow_executions(client, input, http_options \\ []) do
+    request(client, "CountOpenWorkflowExecutions", input, http_options)
   end
 
   @doc """
@@ -104,8 +104,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def count_pending_activity_tasks(client, input, options \\ []) do
-    request(client, "CountPendingActivityTasks", input, options)
+  def count_pending_activity_tasks(client, input, http_options \\ []) do
+    request(client, "CountPendingActivityTasks", input, http_options)
   end
 
   @doc """
@@ -131,8 +131,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def count_pending_decision_tasks(client, input, options \\ []) do
-    request(client, "CountPendingDecisionTasks", input, options)
+  def count_pending_decision_tasks(client, input, http_options \\ []) do
+    request(client, "CountPendingDecisionTasks", input, http_options)
   end
 
   @doc """
@@ -162,8 +162,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def deprecate_activity_type(client, input, options \\ []) do
-    request(client, "DeprecateActivityType", input, options)
+  def deprecate_activity_type(client, input, http_options \\ []) do
+    request(client, "DeprecateActivityType", input, http_options)
   end
 
   @doc """
@@ -192,8 +192,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def deprecate_domain(client, input, options \\ []) do
-    request(client, "DeprecateDomain", input, options)
+  def deprecate_domain(client, input, http_options \\ []) do
+    request(client, "DeprecateDomain", input, http_options)
   end
 
   @doc """
@@ -223,8 +223,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def deprecate_workflow_type(client, input, options \\ []) do
-    request(client, "DeprecateWorkflowType", input, options)
+  def deprecate_workflow_type(client, input, http_options \\ []) do
+    request(client, "DeprecateWorkflowType", input, http_options)
   end
 
   @doc """
@@ -251,8 +251,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def describe_activity_type(client, input, options \\ []) do
-    request(client, "DescribeActivityType", input, options)
+  def describe_activity_type(client, input, http_options \\ []) do
+    request(client, "DescribeActivityType", input, http_options)
   end
 
   @doc """
@@ -275,8 +275,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def describe_domain(client, input, options \\ []) do
-    request(client, "DescribeDomain", input, options)
+  def describe_domain(client, input, http_options \\ []) do
+    request(client, "DescribeDomain", input, http_options)
   end
 
   @doc """
@@ -301,8 +301,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def describe_workflow_execution(client, input, options \\ []) do
-    request(client, "DescribeWorkflowExecution", input, options)
+  def describe_workflow_execution(client, input, http_options \\ []) do
+    request(client, "DescribeWorkflowExecution", input, http_options)
   end
 
   @doc """
@@ -329,8 +329,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def describe_workflow_type(client, input, options \\ []) do
-    request(client, "DescribeWorkflowType", input, options)
+  def describe_workflow_type(client, input, http_options \\ []) do
+    request(client, "DescribeWorkflowType", input, http_options)
   end
 
   @doc """
@@ -356,8 +356,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def get_workflow_execution_history(client, input, options \\ []) do
-    request(client, "GetWorkflowExecutionHistory", input, options)
+  def get_workflow_execution_history(client, input, http_options \\ []) do
+    request(client, "GetWorkflowExecutionHistory", input, http_options)
   end
 
   @doc """
@@ -383,8 +383,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def list_activity_types(client, input, options \\ []) do
-    request(client, "ListActivityTypes", input, options)
+  def list_activity_types(client, input, http_options \\ []) do
+    request(client, "ListActivityTypes", input, http_options)
   end
 
   @doc """
@@ -415,8 +415,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def list_closed_workflow_executions(client, input, options \\ []) do
-    request(client, "ListClosedWorkflowExecutions", input, options)
+  def list_closed_workflow_executions(client, input, http_options \\ []) do
+    request(client, "ListClosedWorkflowExecutions", input, http_options)
   end
 
   @doc """
@@ -444,8 +444,8 @@ defmodule AWS.SWF do
   SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def list_domains(client, input, options \\ []) do
-    request(client, "ListDomains", input, options)
+  def list_domains(client, input, http_options \\ []) do
+    request(client, "ListDomains", input, http_options)
   end
 
   @doc """
@@ -476,8 +476,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def list_open_workflow_executions(client, input, options \\ []) do
-    request(client, "ListOpenWorkflowExecutions", input, options)
+  def list_open_workflow_executions(client, input, http_options \\ []) do
+    request(client, "ListOpenWorkflowExecutions", input, http_options)
   end
 
   @doc """
@@ -501,8 +501,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def list_workflow_types(client, input, options \\ []) do
-    request(client, "ListWorkflowTypes", input, options)
+  def list_workflow_types(client, input, http_options \\ []) do
+    request(client, "ListWorkflowTypes", input, http_options)
   end
 
   @doc """
@@ -535,8 +535,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def poll_for_activity_task(client, input, options \\ []) do
-    request(client, "PollForActivityTask", input, options)
+  def poll_for_activity_task(client, input, http_options \\ []) do
+    request(client, "PollForActivityTask", input, http_options)
   end
 
   @doc """
@@ -578,8 +578,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def poll_for_decision_task(client, input, options \\ []) do
-    request(client, "PollForDecisionTask", input, options)
+  def poll_for_decision_task(client, input, http_options \\ []) do
+    request(client, "PollForDecisionTask", input, http_options)
   end
 
   @doc """
@@ -626,8 +626,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def record_activity_task_heartbeat(client, input, options \\ []) do
-    request(client, "RecordActivityTaskHeartbeat", input, options)
+  def record_activity_task_heartbeat(client, input, http_options \\ []) do
+    request(client, "RecordActivityTaskHeartbeat", input, http_options)
   end
 
   @doc """
@@ -657,8 +657,8 @@ defmodule AWS.SWF do
   SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def register_activity_type(client, input, options \\ []) do
-    request(client, "RegisterActivityType", input, options)
+  def register_activity_type(client, input, http_options \\ []) do
+    request(client, "RegisterActivityType", input, http_options)
   end
 
   @doc """
@@ -681,8 +681,8 @@ defmodule AWS.SWF do
   SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def register_domain(client, input, options \\ []) do
-    request(client, "RegisterDomain", input, options)
+  def register_domain(client, input, http_options \\ []) do
+    request(client, "RegisterDomain", input, http_options)
   end
 
   @doc """
@@ -715,8 +715,8 @@ defmodule AWS.SWF do
   SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def register_workflow_type(client, input, options \\ []) do
-    request(client, "RegisterWorkflowType", input, options)
+  def register_workflow_type(client, input, http_options \\ []) do
+    request(client, "RegisterWorkflowType", input, http_options)
   end
 
   @doc """
@@ -747,8 +747,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def request_cancel_workflow_execution(client, input, options \\ []) do
-    request(client, "RequestCancelWorkflowExecution", input, options)
+  def request_cancel_workflow_execution(client, input, http_options \\ []) do
+    request(client, "RequestCancelWorkflowExecution", input, http_options)
   end
 
   @doc """
@@ -785,8 +785,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def respond_activity_task_canceled(client, input, options \\ []) do
-    request(client, "RespondActivityTaskCanceled", input, options)
+  def respond_activity_task_canceled(client, input, http_options \\ []) do
+    request(client, "RespondActivityTaskCanceled", input, http_options)
   end
 
   @doc """
@@ -823,8 +823,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def respond_activity_task_completed(client, input, options \\ []) do
-    request(client, "RespondActivityTaskCompleted", input, options)
+  def respond_activity_task_completed(client, input, http_options \\ []) do
+    request(client, "RespondActivityTaskCompleted", input, http_options)
   end
 
   @doc """
@@ -856,8 +856,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def respond_activity_task_failed(client, input, options \\ []) do
-    request(client, "RespondActivityTaskFailed", input, options)
+  def respond_activity_task_failed(client, input, http_options \\ []) do
+    request(client, "RespondActivityTaskFailed", input, http_options)
   end
 
   @doc """
@@ -880,8 +880,8 @@ defmodule AWS.SWF do
   [Using IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def respond_decision_task_completed(client, input, options \\ []) do
-    request(client, "RespondDecisionTaskCompleted", input, options)
+  def respond_decision_task_completed(client, input, http_options \\ []) do
+    request(client, "RespondDecisionTaskCompleted", input, http_options)
   end
 
   @doc """
@@ -910,8 +910,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def signal_workflow_execution(client, input, options \\ []) do
-    request(client, "SignalWorkflowExecution", input, options)
+  def signal_workflow_execution(client, input, http_options \\ []) do
+    request(client, "SignalWorkflowExecution", input, http_options)
   end
 
   @doc """
@@ -945,8 +945,8 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def start_workflow_execution(client, input, options \\ []) do
-    request(client, "StartWorkflowExecution", input, options)
+  def start_workflow_execution(client, input, http_options \\ []) do
+    request(client, "StartWorkflowExecution", input, http_options)
   end
 
   @doc """
@@ -979,11 +979,11 @@ defmodule AWS.SWF do
   IAM to Manage Access to Amazon SWF
   Workflows](http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html).
   """
-  def terminate_workflow_execution(client, input, options \\ []) do
-    request(client, "TerminateWorkflowExecution", input, options)
+  def terminate_workflow_execution(client, input, http_options \\ []) do
+    request(client, "TerminateWorkflowExecution", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "swf"}
     host = "swf.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -992,12 +992,12 @@ defmodule AWS.SWF do
                {"X-Amz-Target", "SimpleWorkflowService.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/transcoder.ex
+++ b/lib/aws/transcoder.ex
@@ -16,10 +16,10 @@ defmodule AWS.Transcoder do
   job identifier, use `UpdatePipelineStatus` to temporarily pause the
   pipeline.</note>
   """
-  def cancel_job(client, id, input, options \\ []) do
+  def cancel_job(client, id, input, http_options \\ []) do
     url = "/2012-09-25/jobs/#{URI.encode(id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 202)
+    request(client, :delete, url, headers, input, http_options, 202)
   end
 
   @doc """
@@ -32,20 +32,20 @@ defmodule AWS.Transcoder do
   currently must use the Elastic Transcoder API to list the jobs (as opposed
   to the AWS Console).
   """
-  def create_job(client, input, options \\ []) do
+  def create_job(client, input, http_options \\ []) do
     url = "/2012-09-25/jobs"
     headers = []
-    request(client, :post, url, headers, input, options, 201)
+    request(client, :post, url, headers, input, http_options, 201)
   end
 
   @doc """
   The CreatePipeline operation creates a pipeline with settings that you
   specify.
   """
-  def create_pipeline(client, input, options \\ []) do
+  def create_pipeline(client, input, http_options \\ []) do
     url = "/2012-09-25/pipelines"
     headers = []
-    request(client, :post, url, headers, input, options, 201)
+    request(client, :post, url, headers, input, http_options, 201)
   end
 
   @doc """
@@ -65,10 +65,10 @@ defmodule AWS.Transcoder do
   see the International Telecommunication Union publication *Recommendation
   ITU-T H.264: Advanced video coding for generic audiovisual services*.
   """
-  def create_preset(client, input, options \\ []) do
+  def create_preset(client, input, http_options \\ []) do
     url = "/2012-09-25/presets"
     headers = []
-    request(client, :post, url, headers, input, options, 201)
+    request(client, :post, url, headers, input, http_options, 201)
   end
 
   @doc """
@@ -78,10 +78,10 @@ defmodule AWS.Transcoder do
   currently in use (doesn't contain any active jobs). If the pipeline is
   currently in use, `DeletePipeline` returns an error.
   """
-  def delete_pipeline(client, id, input, options \\ []) do
+  def delete_pipeline(client, id, input, http_options \\ []) do
     url = "/2012-09-25/pipelines/#{URI.encode(id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 202)
+    request(client, :delete, url, headers, input, http_options, 202)
   end
 
   @doc """
@@ -93,10 +93,10 @@ defmodule AWS.Transcoder do
 
   </note>
   """
-  def delete_preset(client, id, input, options \\ []) do
+  def delete_preset(client, id, input, http_options \\ []) do
     url = "/2012-09-25/presets/#{URI.encode(id)}"
     headers = []
-    request(client, :delete, url, headers, input, options, 202)
+    request(client, :delete, url, headers, input, http_options, 202)
   end
 
   @doc """
@@ -107,10 +107,10 @@ defmodule AWS.Transcoder do
   pipeline. The response body contains one element for each job that
   satisfies the search criteria.
   """
-  def list_jobs_by_pipeline(client, pipeline_id, options \\ []) do
+  def list_jobs_by_pipeline(client, pipeline_id, http_options \\ []) do
     url = "/2012-09-25/jobsByPipeline/#{URI.encode(pipeline_id)}"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -118,57 +118,57 @@ defmodule AWS.Transcoder do
   status. The response body contains one element for each job that satisfies
   the search criteria.
   """
-  def list_jobs_by_status(client, status, options \\ []) do
+  def list_jobs_by_status(client, status, http_options \\ []) do
     url = "/2012-09-25/jobsByStatus/#{URI.encode(status)}"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
   The ListPipelines operation gets a list of the pipelines associated with
   the current AWS account.
   """
-  def list_pipelines(client, options \\ []) do
+  def list_pipelines(client, http_options \\ []) do
     url = "/2012-09-25/pipelines"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
   The ListPresets operation gets a list of the default presets included with
   Elastic Transcoder and the presets that you've added in an AWS region.
   """
-  def list_presets(client, options \\ []) do
+  def list_presets(client, http_options \\ []) do
     url = "/2012-09-25/presets"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
   The ReadJob operation returns detailed information about a job.
   """
-  def read_job(client, id, options \\ []) do
+  def read_job(client, id, http_options \\ []) do
     url = "/2012-09-25/jobs/#{URI.encode(id)}"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
   The ReadPipeline operation gets detailed information about a pipeline.
   """
-  def read_pipeline(client, id, options \\ []) do
+  def read_pipeline(client, id, http_options \\ []) do
     url = "/2012-09-25/pipelines/#{URI.encode(id)}"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
   The ReadPreset operation gets detailed information about a preset.
   """
-  def read_preset(client, id, options \\ []) do
+  def read_preset(client, id, http_options \\ []) do
     url = "/2012-09-25/presets/#{URI.encode(id)}"
     headers = []
-    request(client, :get, url, headers, nil, options, nil)
+    request(client, :get, url, headers, nil, http_options, nil)
   end
 
   @doc """
@@ -180,10 +180,10 @@ defmodule AWS.Transcoder do
   specified IAM role, checks read access to the input and output buckets, and
   tries to send a test notification to Amazon SNS topics that you specify.
   """
-  def test_role(client, input, options \\ []) do
+  def test_role(client, input, http_options \\ []) do
     url = "/2012-09-25/roleTests"
     headers = []
-    request(client, :post, url, headers, input, options, 200)
+    request(client, :post, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -193,10 +193,10 @@ defmodule AWS.Transcoder do
   Transcoder has not started to process are affected in addition to jobs that
   you submit after you change settings. </important>
   """
-  def update_pipeline(client, id, input, options \\ []) do
+  def update_pipeline(client, id, input, http_options \\ []) do
     url = "/2012-09-25/pipelines/#{URI.encode(id)}"
     headers = []
-    request(client, :put, url, headers, input, options, 200)
+    request(client, :put, url, headers, input, http_options, 200)
   end
 
   @doc """
@@ -206,10 +206,10 @@ defmodule AWS.Transcoder do
   When you update notifications for a pipeline, Elastic Transcoder returns
   the values that you specified in the request.
   """
-  def update_pipeline_notifications(client, id, input, options \\ []) do
+  def update_pipeline_notifications(client, id, input, http_options \\ []) do
     url = "/2012-09-25/pipelines/#{URI.encode(id)}/notifications"
     headers = []
-    request(client, :post, url, headers, input, options, nil)
+    request(client, :post, url, headers, input, http_options, nil)
   end
 
   @doc """
@@ -222,13 +222,13 @@ defmodule AWS.Transcoder do
   more time to get the job IDs for the jobs that you want to cancel, and to
   send a `CancelJob` request.
   """
-  def update_pipeline_status(client, id, input, options \\ []) do
+  def update_pipeline_status(client, id, input, http_options \\ []) do
     url = "/2012-09-25/pipelines/#{URI.encode(id)}/status"
     headers = []
-    request(client, :post, url, headers, input, options, nil)
+    request(client, :post, url, headers, input, http_options, nil)
   end
 
-  defp request(client, method, url, headers, input, options, success_status_code) do
+  defp request(client, method, url, headers, input, http_options, success_status_code) do
     client = %{client | service: "elastictranscoder"}
     host = "elastictranscoder.#{client.region}.#{client.endpoint}"
     url = "https://#{host}#{url}"
@@ -237,32 +237,32 @@ defmodule AWS.Transcoder do
                           headers)
     payload = encode_payload(input)
     headers = AWS.Request.sign_v4(client, method, url, headers, payload)
-    perform_request(method, url, payload, headers, options, success_status_code)
+    perform_request(method, url, payload, headers, http_options, success_status_code)
   end
 
-  defp perform_request(method, url, payload, headers, options, nil) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, nil) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 202, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, response=%HTTPoison.Response{status_code: 204, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end
   end
 
-  defp perform_request(method, url, payload, headers, options, success_status_code) do
-    case HTTPoison.request(method, url, payload, headers, options) do
+  defp perform_request(method, url, payload, headers, http_options, success_status_code) do
+    case HTTPoison.request(method, url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["message"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end

--- a/lib/aws/workspaces.ex
+++ b/lib/aws/workspaces.ex
@@ -18,8 +18,8 @@ defmodule AWS.Workspaces do
 
   </note>
   """
-  def create_workspaces(client, input, options \\ []) do
-    request(client, "CreateWorkspaces", input, options)
+  def create_workspaces(client, input, http_options \\ []) do
+    request(client, "CreateWorkspaces", input, http_options)
   end
 
   @doc """
@@ -34,8 +34,8 @@ defmodule AWS.Workspaces do
   response member contains a token that you pass in the next call to this
   operation to retrieve the next set of items.
   """
-  def describe_workspace_bundles(client, input, options \\ []) do
-    request(client, "DescribeWorkspaceBundles", input, options)
+  def describe_workspace_bundles(client, input, http_options \\ []) do
+    request(client, "DescribeWorkspaceBundles", input, http_options)
   end
 
   @doc """
@@ -48,8 +48,8 @@ defmodule AWS.Workspaces do
   response member contains a token that you pass in the next call to this
   operation to retrieve the next set of items.
   """
-  def describe_workspace_directories(client, input, options \\ []) do
-    request(client, "DescribeWorkspaceDirectories", input, options)
+  def describe_workspace_directories(client, input, http_options \\ []) do
+    request(client, "DescribeWorkspaceDirectories", input, http_options)
   end
 
   @doc """
@@ -63,8 +63,8 @@ defmodule AWS.Workspaces do
   response member contains a token that you pass in the next call to this
   operation to retrieve the next set of items.
   """
-  def describe_workspaces(client, input, options \\ []) do
-    request(client, "DescribeWorkspaces", input, options)
+  def describe_workspaces(client, input, http_options \\ []) do
+    request(client, "DescribeWorkspaces", input, http_options)
   end
 
   @doc """
@@ -78,8 +78,8 @@ defmodule AWS.Workspaces do
 
   </note>
   """
-  def reboot_workspaces(client, input, options \\ []) do
-    request(client, "RebootWorkspaces", input, options)
+  def reboot_workspaces(client, input, http_options \\ []) do
+    request(client, "RebootWorkspaces", input, http_options)
   end
 
   @doc """
@@ -103,8 +103,8 @@ defmodule AWS.Workspaces do
 
   </note>
   """
-  def rebuild_workspaces(client, input, options \\ []) do
-    request(client, "RebuildWorkspaces", input, options)
+  def rebuild_workspaces(client, input, http_options \\ []) do
+    request(client, "RebuildWorkspaces", input, http_options)
   end
 
   @doc """
@@ -122,11 +122,11 @@ defmodule AWS.Workspaces do
 
   </note>
   """
-  def terminate_workspaces(client, input, options \\ []) do
-    request(client, "TerminateWorkspaces", input, options)
+  def terminate_workspaces(client, input, http_options \\ []) do
+    request(client, "TerminateWorkspaces", input, http_options)
   end
 
-  defp request(client, action, input, options) do
+  defp request(client, action, input, http_options) do
     client = %{client | service: "workspaces"}
     host = "workspaces.#{client.region}.#{client.endpoint}"
     url = "https://#{host}/"
@@ -135,12 +135,12 @@ defmodule AWS.Workspaces do
                {"X-Amz-Target", "WorkspacesService.#{action}"}]
     payload = Poison.Encoder.encode(input, [])
     headers = AWS.Request.sign_v4(client, "POST", url, headers, payload)
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, http_options) do
       {:ok, response=%HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
-      {:ok, _response=%HTTPoison.Response{body: body}} ->
+      {:ok, response=%HTTPoison.Response{body: body}} ->
         reason = Poison.Parser.parse!(body)["__type"]
-        {:error, reason}
+        {:error, reason, response}
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, %HTTPoison.Error{reason: reason}}
     end


### PR DESCRIPTION
Include HTTP response data in result data when a request receives an
unsuccessful HTTP status code.  The `options` parameter has been
renamed to `http_options` to make its intent a bit more clear.
