### PR TITLE
[wip] Add a Client.Provider that will go through a chain of providers.

### DIFF
--- a/lib/aws/client.ex
+++ b/lib/aws/client.ex
@@ -5,7 +5,21 @@ defmodule AWS.Client do
 
   defstruct access_key_id: nil,
             secret_access_key: nil,
+            token: nil,
             region: nil,
-            endpoint: nil,
-            service: nil
+            endpoint: "amazonaws.com",
+            service: nil,
+            expires_at: nil
+
+  @type t :: %AWS.Client{}
+
+  @spec merge(AWS.Client.t, AWS.Client.t) :: AWS.Client.t
+  def merge(a, b) do
+    Map.merge a, b, fn
+      (_k, v1, nil) ->
+        v1
+      (_k, _v1, v2) ->
+        v2
+    end
+  end
 end

--- a/lib/aws/client/environment_provider.ex
+++ b/lib/aws/client/environment_provider.ex
@@ -1,0 +1,32 @@
+defmodule AWS.Client.EnvironmentProvider do
+  @behaviour AWS.Client.Provider
+
+  alias AWS.Client
+
+  def client(%Client{} = initial_client \\ %Client{}) do
+    Client.merge(initial_client, credentials_from_environment)
+  end
+
+  defp credentials_from_environment do
+    %Client{
+      access_key_id: get_env(
+        ~w(AWS_ACCESS_KEY_ID AMAZON_ACCESS_KEY_ID AWS_ACCESS_KEY)),
+      secret_access_key: get_env(
+        ~w(AWS_SECRET_ACCESS_KEY AMAZON_SECRET_ACCESS_KEY AWS_SECRET_KEY)),
+      token: get_env(
+        ~w(AWS_SESSION_TOKEN AMAZON_SESSION_TOKEN)),
+      region: get_env(
+        ~w(AWS_REGION))
+    }
+  end
+
+  defp get_env(keys) when is_list(keys) do
+    Enum.reduce keys, nil, fn(key, acc) ->
+      case {acc, System.get_env(key)} do
+        {a, _b} when not is_nil(a) -> a
+        {nil, b} when not is_nil(b) -> b
+        _ -> nil
+      end
+    end
+  end
+end

--- a/lib/aws/client/instance_profile_provider.ex
+++ b/lib/aws/client/instance_profile_provider.ex
@@ -1,0 +1,53 @@
+defmodule AWS.Client.InstanceProfileProvider do
+  @behaviour AWS.Client.Provider
+
+  alias AWS.Client
+
+  @metadata_url "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+  @metadata_timeout 500
+
+  def client(%Client{} = initial_client \\ %Client{}) do
+    instance_creds = instance_profiles
+    |> List.first
+    |> credentials_for_profile
+
+    case instance_creds do
+      {:error, _} ->
+        initial_client
+      new_client ->
+        Client.merge(initial_client, new_client)
+    end
+  end
+
+  defp instance_profiles do
+    case HTTPoison.get(@metadata_url, [], timeout: @metadata_timeout) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        String.split body, "\n"
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp credentials_for_profile(nil), do: {:error, :no_profiles}
+
+  defp credentials_for_profile(profile) do
+    url = @metadata_url <> profile
+    case HTTPoison.get(url, [], timeout: @metadata_timeout) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, payload} = Poison.decode(body)
+
+        {:ok, expires_at} = Timex.DateFormat.parse(
+          payload["Expiration"],
+          "{ISOz}")
+
+        %Client{
+          access_key_id: payload["AccessKeyId"],
+          secret_access_key: payload["SecretAccessKey"],
+          token: payload["Token"],
+          expires_at: expires_at
+        }
+      {:error, _} = e ->
+        e
+    end
+  end
+end

--- a/lib/aws/client/provider.ex
+++ b/lib/aws/client/provider.ex
@@ -1,0 +1,26 @@
+defmodule AWS.Client.Provider do
+  use Behaviour
+
+  @doc "Returns a valid client struct."
+  defcallback client(client :: AWS.Client.t) :: AWS.Client.t
+
+  alias AWS.Client
+
+  # Because we're using reduce and merge, the highest priority providers should
+  # be at the bottom of the list.
+  @providers [
+    AWS.Client.InstanceProfileProvider,
+    AWS.Client.EnvironmentProvider,
+  ]
+
+  @doc """
+  Returns a client from the environment. Uses the following:
+
+  * Environment variables (AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID)
+  * EC2 Instance Profile (IAM Role) when running on an EC2 instance
+  """
+  @spec get_client(AWS.Client.t) :: AWS.Client.t
+  def get_client(%Client{} = initial_client \\ %Client{}) do
+    Enum.reduce @providers, initial_client, &(apply &1, :client, [&2])
+  end
+end


### PR DESCRIPTION
This is still a work in progress; most of it is minimally functional, but I wanted to share my work to see if this is a direction you want to proceed with.

Here's a rough to-do list for what I want to see in this PR.
- [x] Getting credentials from environment variables
- [ ] Getting credentials from the `~/.aws/config` and `~/.aws/credentials` files
- [x] Getting credentials from EC2 instance metadata (IAM role)
- [ ] EC2 instance metadata failure retry modes
