### PR TITLE
Add condition to not parse body if empty

### DIFF
--- a/lib/aws/lambda.ex
+++ b/lib/aws/lambda.ex
@@ -467,6 +467,8 @@ defmodule AWS.Lambda do
 
   defp perform_request(method, url, payload, headers, options, success_status_code) do
     case HTTPoison.request(method, url, payload, headers, options) do
+      {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: ""}} ->
+        {:ok, nil, response}
       {:ok, response=%HTTPoison.Response{status_code: ^success_status_code, body: body}} ->
         {:ok, Poison.Parser.parse!(body), response}
       {:ok, _response=%HTTPoison.Response{body: body}} ->


### PR DESCRIPTION
Invoking Lambda functions async return a HTTP 202 and with blank body.
Added a condition to not parse request body if request is successful but empty.