### PR TITLE
Updated to Timex 3.1

### DIFF
--- a/lib/aws/request.ex
+++ b/lib/aws/request.ex
@@ -6,7 +6,7 @@ defmodule AWS.Request do
   Generate headers with an AWS signature version 4 for the specified request.
   """
   def sign_v4(client, method, url, headers, body) do
-    sign_v4(client, Timex.DateTime.universal, method, url, headers, body)
+    sign_v4(client, Timex.now, method, url, headers, body)
   end
 
   @doc """
@@ -37,7 +37,7 @@ defmodule AWS.Request do
   Generate headers with an AWS signature version 4 for the specified request that can be transformed into a query string.
   """
   def sign_v4_query(client, method, url, headers, body) do
-    sign_v4_query(client, Timex.DateTime.universal, method, url, headers, body)
+    sign_v4_query(client, Timex.now, method, url, headers, body)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule AWS.Mixfile do
      name: "aws-elixir",
      source_url: "https://github.com/jkakar/aws-elixir",
      homepage_url: "http://github.com/jkakar/aws-elixir",
-     elixir: "~> 1.2",
+     elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps]
@@ -37,7 +37,7 @@ defmodule AWS.Mixfile do
      {:ex_doc, "~> 0.11.3", only: [:dev]},
      {:httpoison, "~> 0.10.0"},
      {:poison, "~> 1.5 or ~> 2.0"},
-     {:timex, "~> 2.1"}]
+     {:timex, "~> 3.1"}]
   end
 
   defp version do

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
 %{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
-  "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
+  "combine": {:hex, :combine, "0.9.3", "192e609b48b3f2210494e26f85db1712657be1a8f15795656710317ea43fc449", [:mix], []},
   "dialyxir": {:hex, :dialyxir, "0.3.5", "eaba092549e044c76f83165978979f60110dc58dd5b92fd952bf2312f64e9b14", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
+  "gettext": {:hex, :gettext, "0.13.0", "daafbddc5cda12738bb93b01d84105fe75b916a302f1c50ab9fb066b95ec9db4", [:mix], []},
   "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:mix, :rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.10.0", "4727b3a5e57e9a4ff168a3c2883e20f1208103a41bccc4754f15a9366f49b676", [:mix], [{:hackney, "~> 1.6.3", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
@@ -11,5 +11,5 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "timex": {:hex, :timex, "2.2.1", "0d69012a7fd69f4cbdaa00cc5f2a5f30f1bed56072fb362ed4bddf60db343022", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
+  "timex": {:hex, :timex, "3.1.5", "413d6d8d6f0162a5d47080cb8ca520d790184ac43e097c95191c7563bf25b428", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
   "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}

--- a/test/aws/request_test.exs
+++ b/test/aws/request_test.exs
@@ -8,7 +8,7 @@ defmodule AWS.RequestTest do
                      secret_access_key: "secret-access-key",
                      region: "us-east-1",
                      service: "ec2"}
-    now = Timex.DateTime.from({{2015, 5, 14}, {16, 50, 5}})
+    now = ~N[2015-05-14 16:50:05]
     method = "GET"
     url = "https://ec2.us-east-1.amazonaws.com?Action=DescribeInstances&Version=2014-10-01"
     headers = [{"Host", "ec2.us-east-1.amazonaws.com"}, {"Header", "Value"}]
@@ -25,7 +25,7 @@ defmodule AWS.RequestTest do
                      secret_access_key: "secret-access-key",
                      region: "us-east-1",
                      service: "ec2"}
-    now = Timex.DateTime.from({{2015, 5, 14}, {16, 50, 5}})
+    now = ~N[2015-05-14 16:50:05]
     method = "GET"
     url = "https://s3.us-east-1.amazonaws.com/bucket"
     headers = [{"Host", "ec2.us-east-1.amazonaws.com"},


### PR DESCRIPTION
This update requires an update to Elixir 1.3 (which natively support Date, DateTime and NaiveDateTime)
