### PR TITLE
Update Readme.md for elixir 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ iex> IO.inspect result
   end
   ```
 
-* Configure the OTP application to start `aws-elixir`
+* Configure the OTP application to start `aws-elixir` 
+
+  _Note: If you are using elixir 1.4, you can skip this step_
 
   ```elixir
   def application do


### PR DESCRIPTION
Starting elixir 1.4, deps are automatically inferred as long as the application is empty